### PR TITLE
Set authority as optional signer

### DIFF
--- a/clients/cli/src/commands/create.rs
+++ b/clients/cli/src/commands/create.rs
@@ -31,7 +31,7 @@ pub fn handle_create(args: CreateArgs) -> Result<()> {
 
     let ix = Create {
         asset,
-        authority,
+        authority: (authority, false),
         owner,
         payer: Some(authority),
         group: None,

--- a/clients/js/asset/src/generated/instructions/create.ts
+++ b/clients/js/asset/src/generated/instructions/create.ts
@@ -34,7 +34,7 @@ export type CreateInstructionAccounts = {
   /** Asset account */
   asset: Signer;
   /** The authority of the asset */
-  authority?: PublicKey | Pda;
+  authority?: PublicKey | Pda | Signer;
   /** The owner of the asset */
   owner?: PublicKey | Pda;
   /** Asset account of the group */
@@ -135,7 +135,7 @@ export function create(
 
   // Default values.
   if (!resolvedAccounts.authority.value) {
-    resolvedAccounts.authority.value = context.identity.publicKey;
+    resolvedAccounts.authority.value = context.identity;
   }
   if (!resolvedAccounts.owner.value) {
     resolvedAccounts.owner.value = context.identity.publicKey;

--- a/clients/js/asset/test/create.test.ts
+++ b/clients/js/asset/test/create.test.ts
@@ -268,7 +268,7 @@ test('it cannot set a group on create with wrong authority', async (t) => {
     ],
   });
 
-  // When we create an asset with a group with the same authority.
+  // When we create an asset with a group using the wrong authority.
   const asset = generateSigner(umi);
   const promise = create(umi, {
     asset,
@@ -311,7 +311,7 @@ test('it cannot set a group on create with authority not a signer', async (t) =>
     ],
   });
 
-  // When we create an asset with a group with the same authority.
+  // When we create an asset with a group without the authority as a signer.
   const asset = generateSigner(umi);
   const promise = create(umi, {
     asset,

--- a/clients/js/asset/test/create.test.ts
+++ b/clients/js/asset/test/create.test.ts
@@ -278,7 +278,7 @@ test('it cannot set a group on create with wrong authority', async (t) => {
   }).sendAndConfirm(umi);
 
   // Then we expect an error.
-  await t.throwsAsync(promise, { message: /Invalid22 authority/ });
+  await t.throwsAsync(promise, { message: /Invalid authority/ });
 });
 
 test('it cannot set a group on create with authority not a signer', async (t) => {
@@ -322,5 +322,5 @@ test('it cannot set a group on create with authority not a signer', async (t) =>
   }).sendAndConfirm(umi);
 
   // Then we expect an error.
-  await t.throwsAsync(promise, { message: /missing22 required signature/ });
+  await t.throwsAsync(promise, { message: /missing required signature/ });
 });

--- a/clients/rust/asset/src/generated/instructions/create.rs
+++ b/clients/rust/asset/src/generated/instructions/create.rs
@@ -14,7 +14,7 @@ pub struct Create {
     /// Asset account
     pub asset: solana_program::pubkey::Pubkey,
     /// The authority of the asset
-    pub authority: solana_program::pubkey::Pubkey,
+    pub authority: (solana_program::pubkey::Pubkey, bool),
     /// The owner of the asset
     pub owner: solana_program::pubkey::Pubkey,
     /// Asset account of the group
@@ -43,8 +43,8 @@ impl Create {
             self.asset, true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            self.authority,
-            false,
+            self.authority.0,
+            self.authority.1,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.owner, false,
@@ -113,7 +113,7 @@ pub struct CreateInstructionArgs {
 /// ### Accounts:
 ///
 ///   0. `[writable, signer]` asset
-///   1. `[]` authority
+///   1. `[signer]` authority
 ///   2. `[]` owner
 ///   3. `[writable, optional]` group
 ///   4. `[writable, signer, optional]` payer
@@ -121,7 +121,7 @@ pub struct CreateInstructionArgs {
 #[derive(Default)]
 pub struct CreateBuilder {
     asset: Option<solana_program::pubkey::Pubkey>,
-    authority: Option<solana_program::pubkey::Pubkey>,
+    authority: Option<(solana_program::pubkey::Pubkey, bool)>,
     owner: Option<solana_program::pubkey::Pubkey>,
     group: Option<solana_program::pubkey::Pubkey>,
     payer: Option<solana_program::pubkey::Pubkey>,
@@ -144,8 +144,12 @@ impl CreateBuilder {
     }
     /// The authority of the asset
     #[inline(always)]
-    pub fn authority(&mut self, authority: solana_program::pubkey::Pubkey) -> &mut Self {
-        self.authority = Some(authority);
+    pub fn authority(
+        &mut self,
+        authority: solana_program::pubkey::Pubkey,
+        as_signer: bool,
+    ) -> &mut Self {
+        self.authority = Some((authority, as_signer));
         self
     }
     /// The owner of the asset
@@ -238,7 +242,7 @@ pub struct CreateCpiAccounts<'a, 'b> {
     /// Asset account
     pub asset: &'b solana_program::account_info::AccountInfo<'a>,
     /// The authority of the asset
-    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub authority: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// The owner of the asset
     pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Asset account of the group
@@ -256,7 +260,7 @@ pub struct CreateCpi<'a, 'b> {
     /// Asset account
     pub asset: &'b solana_program::account_info::AccountInfo<'a>,
     /// The authority of the asset
-    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub authority: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// The owner of the asset
     pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Asset account of the group
@@ -325,8 +329,8 @@ impl<'a, 'b> CreateCpi<'a, 'b> {
             true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            *self.authority.key,
-            false,
+            *self.authority.0.key,
+            self.authority.1,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             *self.owner.key,
@@ -382,7 +386,7 @@ impl<'a, 'b> CreateCpi<'a, 'b> {
         let mut account_infos = Vec::with_capacity(6 + 1 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.asset.clone());
-        account_infos.push(self.authority.clone());
+        account_infos.push(self.authority.0.clone());
         account_infos.push(self.owner.clone());
         if let Some(group) = self.group {
             account_infos.push(group.clone());
@@ -410,7 +414,7 @@ impl<'a, 'b> CreateCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable, signer]` asset
-///   1. `[]` authority
+///   1. `[signer]` authority
 ///   2. `[]` owner
 ///   3. `[writable, optional]` group
 ///   4. `[writable, signer, optional]` payer
@@ -447,8 +451,9 @@ impl<'a, 'b> CreateCpiBuilder<'a, 'b> {
     pub fn authority(
         &mut self,
         authority: &'b solana_program::account_info::AccountInfo<'a>,
+        as_signer: bool,
     ) -> &mut Self {
-        self.instruction.authority = Some(authority);
+        self.instruction.authority = Some((authority, as_signer));
         self
     }
     /// The owner of the asset
@@ -580,7 +585,7 @@ impl<'a, 'b> CreateCpiBuilder<'a, 'b> {
 struct CreateCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     asset: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<(&'b solana_program::account_info::AccountInfo<'a>, bool)>,
     owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     group: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/clients/rust/asset/src/mint.rs
+++ b/clients/rust/asset/src/mint.rs
@@ -361,7 +361,7 @@ pub fn mint(args: MintIxArgs) -> Result<Vec<Instruction>, MintError> {
     instructions.push(
         Create {
             asset: args.accounts.asset,
-            authority: args.accounts.owner,
+            authority: (args.accounts.owner, false),
             owner: args.accounts.owner,
             payer: Some(payer),
             group: None,

--- a/clients/rust/asset/tests/create.rs
+++ b/clients/rust/asset/tests/create.rs
@@ -30,7 +30,7 @@ mod create {
 
         let ix = CreateBuilder::new()
             .asset(asset.pubkey())
-            .authority(context.payer.pubkey())
+            .authority(context.payer.pubkey(), false)
             .owner(context.payer.pubkey())
             .payer(Some(context.payer.pubkey()))
             .system_program(Some(system_program::id()))
@@ -108,7 +108,7 @@ mod create {
 
         let ix = CreateBuilder::new()
             .asset(asset.pubkey())
-            .authority(context.payer.pubkey())
+            .authority(context.payer.pubkey(), false)
             .owner(context.payer.pubkey())
             .payer(Some(context.payer.pubkey()))
             .system_program(Some(system_program::id()))

--- a/idls/asset_program.json
+++ b/idls/asset_program.json
@@ -87,6 +87,7 @@
           "name": "authority",
           "isMut": false,
           "isSigner": false,
+          "isOptionalSigner": true,
           "docs": [
             "The authority of the asset"
           ]

--- a/programs/asset/program/src/entrypoint.rs
+++ b/programs/asset/program/src/entrypoint.rs
@@ -1,6 +1,9 @@
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-    program_error::PrintProgramError, pubkey::Pubkey,
+    account_info::AccountInfo,
+    entrypoint,
+    entrypoint::ProgramResult,
+    program_error::{PrintProgramError, ProgramError},
+    pubkey::Pubkey,
 };
 
 use crate::{error::AssetError, processor};
@@ -12,9 +15,16 @@ fn process_instruction<'a>(
     instruction_data: &[u8],
 ) -> ProgramResult {
     if let Err(error) = processor::process_instruction(program_id, accounts, instruction_data) {
-        // catch the error so we can print it
-        error.print::<AssetError>();
+        match error {
+            ProgramError::Custom(_) => {
+                error.print::<AssetError>();
+            }
+            _ => {
+                solana_program::msg!("⛔️ {} ({:?})", &error.to_string(), &error);
+            }
+        }
         return Err(error);
     }
+
     Ok(())
 }

--- a/programs/asset/program/src/error.rs
+++ b/programs/asset/program/src/error.rs
@@ -87,7 +87,7 @@ pub enum AssetError {
 
 impl PrintProgramError for AssetError {
     fn print<E>(&self) {
-        msg!("⛔️ {}", &self.to_string());
+        msg!("⛔️ {} ({:?})", &self.to_string(), &self);
     }
 }
 

--- a/programs/asset/program/src/instruction.rs
+++ b/programs/asset/program/src/instruction.rs
@@ -24,7 +24,7 @@ pub enum Instruction {
 
     /// Creates a new asset.
     #[account(0, signer, writable, name="asset", desc = "Asset account")]
-    #[account(1, name="authority", desc = "The authority of the asset")]
+    #[account(1, optional_signer, name="authority", desc = "The authority of the asset")]
     #[account(2, name="owner", desc = "The owner of the asset")]
     #[account(3, optional, writable, name="group", desc = "Asset account of the group")]
     #[account(4, optional, signer, writable, name="payer", desc = "The account paying for the storage fees")]

--- a/programs/bridge/src/processor/create.rs
+++ b/programs/bridge/src/processor/create.rs
@@ -248,7 +248,7 @@ pub fn process_create(
 
     CreateCpiBuilder::new(ctx.accounts.nifty_asset_program)
         .asset(ctx.accounts.asset)
-        .authority(ctx.accounts.update_authority)
+        .authority(ctx.accounts.update_authority, false)
         .owner(ctx.accounts.vault)
         .payer(Some(ctx.accounts.payer))
         .system_program(Some(ctx.accounts.system_program))


### PR DESCRIPTION
This PR sets the `authority` as an optional signer on the `create` instruction. This allows a different authority than the payer to sing the `create` instruction when a group is being set. Note that the `authority` of the asset must match the `authority` of the group asset for the asset to be added to the group.