### PR TITLE
Add creators extension on bridge

### DIFF
--- a/clients/js/bridge/src/generated/accounts/vault.ts
+++ b/clients/js/bridge/src/generated/accounts/vault.ts
@@ -165,7 +165,7 @@ export function findVaultPda(
     'BridgezKrNugsZwTcyAMYba643Z93RzC2yN1Y24LwAkm'
   );
   return context.eddsa.findPda(programId, [
-    string({ size: 'variable' }).serialize('nifty::bridge::vault'),
+    string({ size: 'variable' }).serialize('vault'),
     publicKeySerializer().serialize(seeds.mint),
   ]);
 }

--- a/clients/js/bridge/src/pda.ts
+++ b/clients/js/bridge/src/pda.ts
@@ -16,7 +16,7 @@ export function findBridgeAssetPda(
     'BridgezKrNugsZwTcyAMYba643Z93RzC2yN1Y24LwAkm'
   );
   return context.eddsa.findPda(programId, [
-    string({ size: 'variable' }).serialize('nifty::bridge::asset'),
+    string({ size: 'variable' }).serialize('asset'),
     publicKeySerializer().serialize(seeds.mint),
   ]);
 }

--- a/clients/js/bridge/test/create.test.ts
+++ b/clients/js/bridge/test/create.test.ts
@@ -3,14 +3,9 @@ import {
   percentAmount,
   publicKey,
 } from '@metaplex-foundation/umi';
-import {
-  publicKey as publicKeySerializer,
-  string,
-} from '@metaplex-foundation/umi/serializers';
 import { Asset, ExtensionType, empty, fetchAsset } from '@nifty-oss/asset';
 import test from 'ava';
 import {
-  BRIDGE_PROGRAM_ID,
   Discriminator,
   State,
   Vault,
@@ -67,10 +62,7 @@ test('it can create an asset on the bridge', async (t) => {
   });
 
   // And the asset is created.
-  const asset = umi.eddsa.findPda(BRIDGE_PROGRAM_ID, [
-    string({ size: 'variable' }).serialize('nifty::bridge::asset'),
-    publicKeySerializer().serialize(mint.publicKey),
-  ]);
+  const asset = findBridgeAssetPda(umi, { mint: mint.publicKey });
   t.like(await fetchAsset(umi, asset), <Asset>{
     extensions: [
       {
@@ -129,10 +121,7 @@ test('it can create a collection asset on the bridge for a pNFT', async (t) => {
   });
 
   // And the asset is created.
-  const asset = umi.eddsa.findPda(BRIDGE_PROGRAM_ID, [
-    string({ size: 'variable' }).serialize('nifty::bridge::asset'),
-    publicKeySerializer().serialize(mint.publicKey),
-  ]);
+  const asset = findBridgeAssetPda(umi, { mint: mint.publicKey });
 
   // An empty constraint is added to the asset representing a 'pass-all' constraint.
   const constraint = empty();
@@ -194,10 +183,7 @@ test('it can create an asset on the bridge for a pNFT', async (t) => {
   });
 
   // And the asset is created.
-  const asset = umi.eddsa.findPda(BRIDGE_PROGRAM_ID, [
-    string({ size: 'variable' }).serialize('nifty::bridge::asset'),
-    publicKeySerializer().serialize(mint.publicKey),
-  ]);
+  const asset = findBridgeAssetPda(umi, { mint: mint.publicKey });
 
   t.like(await fetchAsset(umi, asset), <Asset>{
     extensions: [

--- a/clients/js/bridge/test/create.test.ts
+++ b/clients/js/bridge/test/create.test.ts
@@ -86,13 +86,27 @@ test('it can create a collection asset on the bridge for a pNFT', async (t) => {
   // Given a Umi instance.
   const umi = await createUmi();
 
+  // And a set of creators.
+  const creators = [
+    {
+      address: generateSigner(umi).publicKey,
+      share: 50,
+      verified: false,
+    },
+    {
+      address: generateSigner(umi).publicKey,
+      share: 50,
+      verified: false,
+    },
+  ];
+
   // And a Token Metadata programmable non-fungible.
   const mint = await createProgrammableNft(umi, {
     name: 'Bridge Asset',
     symbol: 'BA',
     uri: 'https://asset.bridge',
     sellerFeeBasisPoints: percentAmount(5.5),
-    mint: undefined,
+    creators,
   });
 
   // When we create the asset on the bridge.
@@ -131,13 +145,17 @@ test('it can create a collection asset on the bridge for a pNFT', async (t) => {
         uri: 'https://asset.bridge',
       },
       {
+        type: ExtensionType.Creators,
+        creators,
+      },
+      {
         type: ExtensionType.Grouping,
-        size: BigInt(0),
-        maxSize: BigInt(0),
+        size: 0n,
+        maxSize: 0n,
       },
       {
         type: ExtensionType.Royalties,
-        basisPoints: BigInt(550),
+        basisPoints: 550n,
         constraint,
       },
     ],
@@ -154,7 +172,6 @@ test('it can create an asset on the bridge for a pNFT', async (t) => {
     symbol: 'BA',
     uri: 'https://asset.bridge',
     sellerFeeBasisPoints: percentAmount(5.5),
-    mint: undefined,
   });
 
   // When we create the asset on the bridge.

--- a/clients/js/bridge/test/royalties.test.ts
+++ b/clients/js/bridge/test/royalties.test.ts
@@ -6,10 +6,6 @@ import {
 } from '@metaplex-foundation/umi';
 import { createUmi as basecreateUmi } from '@metaplex-foundation/umi-bundle-tests';
 import {
-  publicKey as publicKeySerializer,
-  string,
-} from '@metaplex-foundation/umi/serializers';
-import {
   Asset,
   Discriminator as AssetDiscriminator,
   Standard as AssetStandard,
@@ -25,7 +21,6 @@ import {
 } from '@nifty-oss/asset';
 import test from 'ava';
 import {
-  BRIDGE_PROGRAM_ID,
   Discriminator,
   State,
   Vault,
@@ -118,15 +113,10 @@ test('pubkeymatch failing blocks a transfer on a group asset', async (t) => {
   });
 
   // Derive both asset pubkeys
-  const collectionAsset = umi.eddsa.findPda(BRIDGE_PROGRAM_ID, [
-    string({ size: 'variable' }).serialize('nifty::bridge::asset'),
-    publicKeySerializer().serialize(collectionMint.publicKey),
-  ]);
-
-  const itemAsset = umi.eddsa.findPda(BRIDGE_PROGRAM_ID, [
-    string({ size: 'variable' }).serialize('nifty::bridge::asset'),
-    publicKeySerializer().serialize(itemMint.publicKey),
-  ]);
+  const collectionAsset = findBridgeAssetPda(umi, {
+    mint: collectionMint.publicKey,
+  });
+  const itemAsset = findBridgeAssetPda(umi, { mint: itemMint.publicKey });
 
   // Update the item to be a member of the group.
   await group(umi, {

--- a/clients/js/bridge/test/royalties.test.ts
+++ b/clients/js/bridge/test/royalties.test.ts
@@ -182,6 +182,16 @@ test('pubkeymatch failing blocks a transfer on a group asset', async (t) => {
         symbol: 'BA',
         uri: 'https://collection.bridge',
       },
+      {
+        type: ExtensionType.Creators,
+        creators: [
+          {
+            address: umi.identity.publicKey,
+            verified: false,
+            share: 100,
+          },
+        ],
+      },
       grouping(0, 1), // 1 item in the group
       royalties(basisPoints, constraint),
     ],
@@ -234,6 +244,16 @@ test('pubkeymatch failing blocks a transfer on a group asset', async (t) => {
         type: ExtensionType.Metadata,
         symbol: 'BA',
         uri: 'https://collection.bridge',
+      },
+      {
+        type: ExtensionType.Creators,
+        creators: [
+          {
+            address: umi.identity.publicKey,
+            verified: false,
+            share: 100,
+          },
+        ],
       },
       grouping(0, 1), // 1 item in the group
       royalties(basisPoints, newConstraint),

--- a/clients/rust/bridge/src/generated/accounts/vault.rs
+++ b/clients/rust/bridge/src/generated/accounts/vault.rs
@@ -32,21 +32,21 @@ impl Vault {
     ///
     ///   0. `Vault::PREFIX`
     ///   1. mint (`Pubkey`)
-    pub const PREFIX: &'static [u8] = "nifty::bridge::vault".as_bytes();
+    pub const PREFIX: &'static [u8] = "vault".as_bytes();
 
     pub fn create_pda(
         mint: Pubkey,
         bump: u8,
     ) -> Result<solana_program::pubkey::Pubkey, solana_program::pubkey::PubkeyError> {
         solana_program::pubkey::Pubkey::create_program_address(
-            &["nifty::bridge::vault".as_bytes(), mint.as_ref(), &[bump]],
+            &["vault".as_bytes(), mint.as_ref(), &[bump]],
             &crate::BRIDGE_ID,
         )
     }
 
     pub fn find_pda(mint: &Pubkey) -> (solana_program::pubkey::Pubkey, u8) {
         solana_program::pubkey::Pubkey::find_program_address(
-            &["nifty::bridge::vault".as_bytes(), mint.as_ref()],
+            &["vault".as_bytes(), mint.as_ref()],
             &crate::BRIDGE_ID,
         )
     }

--- a/configs/kinobi-bridge.cjs
+++ b/configs/kinobi-bridge.cjs
@@ -64,7 +64,7 @@ kinobi.update(
   k.updateAccountsVisitor({
     vault: {
       seeds: [
-        k.constantPdaSeedNodeFromString("nifty::bridge::vault"),
+        k.constantPdaSeedNodeFromString("vault"),
         k.variablePdaSeedNode(
           "mint",
           k.publicKeyTypeNode(),

--- a/programs/bridge/src/entrypoint.rs
+++ b/programs/bridge/src/entrypoint.rs
@@ -1,6 +1,9 @@
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-    program_error::PrintProgramError, pubkey::Pubkey,
+    account_info::AccountInfo,
+    entrypoint,
+    entrypoint::ProgramResult,
+    program_error::{PrintProgramError, ProgramError},
+    pubkey::Pubkey,
 };
 
 use crate::{error::BridgeError, processor};
@@ -12,8 +15,12 @@ fn process_instruction<'a>(
     instruction_data: &[u8],
 ) -> ProgramResult {
     if let Err(error) = processor::process_instruction(program_id, accounts, instruction_data) {
-        // catch the error so we can print it
-        error.print::<BridgeError>();
+        match error {
+            ProgramError::Custom(_) => error.print::<BridgeError>(),
+            _ => {
+                solana_program::msg!("⛔️ {} ({:?})", &error.to_string(), &error);
+            }
+        }
         return Err(error);
     }
     Ok(())

--- a/programs/bridge/src/error.rs
+++ b/programs/bridge/src/error.rs
@@ -19,7 +19,7 @@ pub enum BridgeError {
 
 impl PrintProgramError for BridgeError {
     fn print<E>(&self) {
-        msg!("⛔️ {}", &self.to_string());
+        msg!("⛔️ {} ({:?})", &self.to_string(), &self);
     }
 }
 

--- a/programs/bridge/src/state/bridged_asset.rs
+++ b/programs/bridge/src/state/bridged_asset.rs
@@ -1,7 +1,7 @@
 use solana_program::pubkey::{Pubkey, PubkeyError};
 
 /// Prefix value for the PDA derivation of bridged assets.
-pub const BRIDGED_ASSET_PREFIX: &[u8] = b"nifty::bridge::asset";
+pub const BRIDGED_ASSET_PREFIX: &[u8] = b"asset";
 
 pub fn create_pda(mint: Pubkey, bump: u8) -> Result<Pubkey, PubkeyError> {
     solana_program::pubkey::Pubkey::create_program_address(

--- a/programs/bridge/src/state/vault.rs
+++ b/programs/bridge/src/state/vault.rs
@@ -28,7 +28,7 @@ impl Vault {
     pub const LEN: usize = std::mem::size_of::<Vault>();
 
     /// Prefix value for the PDA derivation.
-    pub const PREFIX: &'static [u8] = b"nifty::bridge::vault";
+    pub const PREFIX: &'static [u8] = b"vault";
 }
 
 impl ZeroCopy<'_, Vault> for Vault {}


### PR DESCRIPTION
This PR adds the creators extension to the asset when the bridged token has creators. Additionally the Bridge PDA seeds are simplified:
- `nifty::bridge::asset` => `asset`
- `nifty::bridge::vault` => `vault`