### PR TITLE
add macos-14 for m1 builds

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -30,6 +30,7 @@ jobs:
         os:
           - buildjet-8vcpu-ubuntu-2004
           - macos-latest
+          - macos-14
     runs-on: ${{ matrix.os }}
     steps:
       - name: Git checkout


### PR DESCRIPTION
Github added a macos-14 runner back in January, that builds on M1 architecture.