### PR TITLE
Add lifecycle callback

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   build_cli:
+    name: Build
     strategy:
       matrix:
         os:
@@ -54,7 +55,7 @@ jobs:
         uses: nifty-oss/actions/buildjet-cache-crate@v1
         with:
           folder: '.' # The action expects the root of the repository, not the crate subdirectory.
-          key: rust-cli
+          key: rust-cli-${{ runner.os }}
 
       - name: Build Rust CLI
         working-directory: clients/cli
@@ -65,6 +66,6 @@ jobs:
       - name: Upload Rust CLI builds
         uses: actions/upload-artifact@v4
         with:
-          name: rust-cli-build-${{ matrix.os }}
+          name: rust-cli-build-${{ runner.os }}
           path: ./target/release/*nifty-cli-${{ runner.os }}
           if-no-files-found: error

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -57,7 +57,6 @@ jobs:
           key: rust-cli
 
       - name: Build Rust CLI
-        shell: bash
         working-directory: clients/cli
         run: |
           cargo build --all-features --release --bin nifty

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -55,7 +55,7 @@ jobs:
         uses: nifty-oss/actions/buildjet-cache-crate@v1
         with:
           folder: '.' # The action expects the root of the repository, not the crate subdirectory.
-          key: rust-cli-${{ runner.os }}
+          key: rust-cli-${{ matrix.os }}
 
       - name: Build Rust CLI
         working-directory: clients/cli
@@ -66,6 +66,6 @@ jobs:
       - name: Upload Rust CLI builds
         uses: actions/upload-artifact@v4
         with:
-          name: rust-cli-build-${{ runner.os }}
+          name: rust-cli-build-${{ matrix.os }}
           path: ./target/release/*nifty-cli-${{ runner.os }}
           if-no-files-found: error

--- a/clients/rust/asset/tests/create.rs
+++ b/clients/rust/asset/tests/create.rs
@@ -83,7 +83,7 @@ mod create {
 
         let mut attributes = AttributesBuilder::default();
         attributes.add("hat", "nifty");
-        let data = attributes.build();
+        let data = attributes.data();
 
         let ix = AllocateBuilder::new()
             .asset(asset.pubkey())

--- a/programs/asset/types/src/extensions/creators.rs
+++ b/programs/asset/types/src/extensions/creators.rs
@@ -175,10 +175,12 @@ impl CreatorsBuilder {
     }
 }
 
-impl ExtensionBuilder for CreatorsBuilder {
-    const TYPE: ExtensionType = ExtensionType::Creators;
+impl<'a> ExtensionBuilder<'a, Creators<'a>> for CreatorsBuilder {
+    fn build(&'a self) -> Creators<'a> {
+        Creators::from_bytes(&self.data)
+    }
 
-    fn build(&mut self) -> Vec<u8> {
+    fn data(&mut self) -> Vec<u8> {
         std::mem::take(&mut self.data)
     }
 }
@@ -193,11 +195,9 @@ impl Deref for CreatorsBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::extensions::{CreatorsBuilder, ExtensionData};
+    use crate::extensions::{CreatorsBuilder, ExtensionBuilder};
     use podded::pod::PodBool;
     use solana_program::pubkey;
-
-    use super::Creators;
 
     #[test]
     fn test_add() {
@@ -207,7 +207,8 @@ mod tests {
             true,
             100,
         );
-        let list = Creators::from_bytes(&builder);
+        let list = builder.build();
+
         assert_eq!(list.creators.len(), 1);
         assert_eq!(
             list.creators[0].address,

--- a/programs/asset/types/src/extensions/grouping.rs
+++ b/programs/asset/types/src/extensions/grouping.rs
@@ -148,10 +148,12 @@ impl GroupingBuilder {
     }
 }
 
-impl ExtensionBuilder for GroupingBuilder {
-    const TYPE: ExtensionType = ExtensionType::Grouping;
+impl<'a> ExtensionBuilder<'a, Grouping<'a>> for GroupingBuilder {
+    fn build(&'a self) -> Grouping<'a> {
+        Grouping::from_bytes(&self.0)
+    }
 
-    fn build(&mut self) -> Vec<u8> {
+    fn data(&mut self) -> Vec<u8> {
         std::mem::take(&mut self.0)
     }
 }
@@ -166,14 +168,14 @@ impl Deref for GroupingBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::extensions::{ExtensionData, Grouping, GroupingBuilder};
+    use crate::extensions::{ExtensionBuilder, GroupingBuilder};
 
     #[test]
-    fn test_set() {
+    fn test_set_max_size() {
         // max_size set
         let mut builder = GroupingBuilder::default();
         builder.set_max_size(Some(10));
-        let grouping = Grouping::from_bytes(&builder);
+        let grouping = builder.build();
 
         assert_eq!(*grouping.size, 0);
         assert!(grouping.max_size.value().is_some());
@@ -184,7 +186,7 @@ mod tests {
         // "default" max size
 
         let builder = GroupingBuilder::default();
-        let grouping = Grouping::from_bytes(&builder);
+        let grouping = builder.build();
 
         assert_eq!(*grouping.size, 0);
         assert!(grouping.max_size.value().is_none());

--- a/programs/asset/types/src/extensions/metadata.rs
+++ b/programs/asset/types/src/extensions/metadata.rs
@@ -134,10 +134,12 @@ impl MetadataBuilder {
     }
 }
 
-impl ExtensionBuilder for MetadataBuilder {
-    const TYPE: ExtensionType = ExtensionType::Metadata;
+impl<'a> ExtensionBuilder<'a, Metadata<'a>> for MetadataBuilder {
+    fn build(&'a self) -> Metadata<'a> {
+        Metadata::from_bytes(&self.0)
+    }
 
-    fn build(&mut self) -> Vec<u8> {
+    fn data(&mut self) -> Vec<u8> {
         std::mem::take(&mut self.0)
     }
 }
@@ -155,7 +157,7 @@ mod tests {
     use crate::extensions::{ExtensionData, Metadata, MetadataBuilder};
 
     #[test]
-    fn test_add() {
+    fn test_set() {
         let mut builder = MetadataBuilder::default();
         builder.set(
             Some("SMB"),

--- a/programs/asset/types/src/extensions/mod.rs
+++ b/programs/asset/types/src/extensions/mod.rs
@@ -32,6 +32,7 @@ pub use royalties::*;
 use borsh::{BorshDeserialize, BorshSerialize};
 use bytemuck::{Pod, Zeroable};
 use podded::ZeroCopy;
+use std::ops::Deref;
 
 use crate::error::Error;
 
@@ -158,12 +159,15 @@ impl From<ExtensionType> for u32 {
 /// Trait for building an extension.
 ///
 /// The `ExtensionBuilder` encapsulates the logic for building an extension by allocating the
-/// necessary memory and writing the extension data to a buffer. The `build` method can then
-/// be used to get retrieve the data buffer.
-pub trait ExtensionBuilder: Default {
-    const TYPE: ExtensionType;
+/// necessary memory and writing the extension data to a buffer. The `data` method can then
+/// be used to get retrieve the bytes buffer and the `build` method can be used to create the
+/// extension from the buffer.
+pub trait ExtensionBuilder<'a, T: ExtensionData<'a>>: Default + Deref {
+    /// Builds the extension from the data buffer.
+    fn build(&'a self) -> T;
 
-    fn build(&mut self) -> Vec<u8>;
+    /// Returns the data buffer.
+    fn data(&mut self) -> Vec<u8>;
 }
 
 /// Trait to define lifecycle callbacks for an extension.
@@ -219,8 +223,11 @@ macro_rules! validate_extension_type {
 }
 
 validate_extension_type!(
+    (Attributes, AttributesMut),
+    (Blob, BlobMut),
     (Creators, CreatorsMut),
     (Grouping, GroupingMut),
+    (Links, LinksMut),
     (Metadata, MetadataMut),
-    (Royalties, RoyaltiesMut),
+    (Royalties, RoyaltiesMut)
 );

--- a/programs/asset/types/src/extensions/royalties.rs
+++ b/programs/asset/types/src/extensions/royalties.rs
@@ -1,6 +1,8 @@
+use std::ops::Deref;
+
 use crate::constraints::{Constraint, ConstraintBuilder, FromBytes};
 
-use super::{ExtensionData, ExtensionDataMut, ExtensionType, Lifecycle};
+use super::{ExtensionBuilder, ExtensionData, ExtensionDataMut, ExtensionType, Lifecycle};
 
 pub struct Royalties<'a> {
     pub basis_points: &'a u64,
@@ -61,12 +63,22 @@ impl RoyaltiesBuilder {
         self.0.extend_from_slice(&basis_points.to_le_bytes());
         self.0.extend_from_slice(&constraint.build());
     }
+}
 
-    pub fn build(&self) -> Royalties {
+impl<'a> ExtensionBuilder<'a, Royalties<'a>> for RoyaltiesBuilder {
+    fn build(&'a self) -> Royalties<'a> {
         Royalties::from_bytes(&self.0)
     }
 
-    pub fn data(&mut self) -> Vec<u8> {
+    fn data(&mut self) -> Vec<u8> {
         std::mem::take(&mut self.0)
+    }
+}
+
+impl Deref for RoyaltiesBuilder {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/programs/bridge/src/processor/create.rs
+++ b/programs/bridge/src/processor/create.rs
@@ -196,7 +196,7 @@ pub fn process_create(
 
     let mut extension = MetadataBuilder::default();
     extension.set(Some(&metadata.symbol), None, Some(&metadata.uri));
-    let data = extension.build();
+    let data = extension.data();
 
     AllocateCpiBuilder::new(ctx.accounts.nifty_asset_program)
         .asset(ctx.accounts.asset)
@@ -215,7 +215,7 @@ pub fn process_create(
         creators.iter().for_each(|creator| {
             extension.add(&creator.address, creator.verified, creator.share);
         });
-        let data = extension.build();
+        let data = extension.data();
 
         AllocateCpiBuilder::new(ctx.accounts.nifty_asset_program)
             .asset(ctx.accounts.asset)
@@ -232,7 +232,7 @@ pub fn process_create(
     // if this is a collection NFT, we add the group extension
     if args.is_collection || metadata.collection_details.is_some() {
         let mut extension = GroupingBuilder::default();
-        let data = extension.build();
+        let data = extension.data();
 
         AllocateCpiBuilder::new(ctx.accounts.nifty_asset_program)
             .asset(ctx.accounts.asset)


### PR DESCRIPTION
This PR adds a lifecycle callback to all extension so the extension data is validated on creation and update. This involved:
- Adding a `*Mut` struct to each extension (some of them had it already)
- Implementing the `Lifecycle` trait
- Refactored the extension builder trait

The PR also includes a fix for the CI, which had a conflict on the cache name on the CLI build.