### PR TITLE
Check for unknown extension types

### DIFF
--- a/clients/js/asset/src/hooked/assetAccountData.ts
+++ b/clients/js/asset/src/hooked/assetAccountData.ts
@@ -56,10 +56,13 @@ export const getAssetAccountDataSerializer = (): Serializer<
         finalOffset
       );
       const type = header.kind as ExtensionType;
-      const [extension] = getExtensionSerializerFromType(type).deserialize(
-        buffer.subarray(headerOffset, headerOffset + header.length)
-      );
-      extensions.push({ ...extension, type } as TypedExtension);
+
+      if (type) {
+        const [extension] = getExtensionSerializerFromType(type).deserialize(
+          buffer.subarray(headerOffset, headerOffset + header.length)
+        );
+        extensions.push({ ...extension, type } as TypedExtension);
+      }
 
       finalOffset = header.boundary;
     }

--- a/clients/js/asset/src/hooked/assetAccountData.ts
+++ b/clients/js/asset/src/hooked/assetAccountData.ts
@@ -57,7 +57,7 @@ export const getAssetAccountDataSerializer = (): Serializer<
       );
       const type = header.kind as ExtensionType;
 
-      if (type) {
+      if (ExtensionType[type]) {
         const [extension] = getExtensionSerializerFromType(type).deserialize(
           buffer.subarray(headerOffset, headerOffset + header.length)
         );


### PR DESCRIPTION
This PR improves the asset account decoding by only deserializing known extensions.