### PR TITLE
Relax processor lock logic

### DIFF
--- a/programs/asset/program/src/processor/mod.rs
+++ b/programs/asset/program/src/processor/mod.rs
@@ -55,7 +55,7 @@ pub fn process_instruction<'a>(
         // check whether the instruction is allowed to proceed
         if matches!(
             instruction,
-            Instruction::Allocate(_)
+            Instruction::Approve(_)
                 | Instruction::Burn
                 | Instruction::Lock
                 | Instruction::Revoke(_)

--- a/programs/asset/program/src/processor/mod.rs
+++ b/programs/asset/program/src/processor/mod.rs
@@ -52,8 +52,15 @@ pub fn process_instruction<'a>(
         .map_err(|_| ProgramError::InvalidInstructionData)?;
 
     if let Some(account) = is_locked(program_id, accounts) {
-        // if we are not unlocking the asset, then we block the instruction
-        if !matches!(instruction, Instruction::Unlock) {
+        // check whether the instruction is allowed to proceed
+        if matches!(
+            instruction,
+            Instruction::Allocate(_)
+                | Instruction::Burn
+                | Instruction::Lock
+                | Instruction::Revoke(_)
+                | Instruction::Transfer
+        ) {
             return err!(AssetError::LockedAsset, "Asset \"{}\" is locked", account);
         }
     }


### PR DESCRIPTION
This PR relaxes the processor constraint when an asset is `Locked` by specifying explicitly the list of instruction not allowed to proceed.