### PR TITLE
Add authority on lifecycle callback

### DIFF
--- a/clients/js/asset/test/verify.test.ts
+++ b/clients/js/asset/test/verify.test.ts
@@ -17,12 +17,13 @@ test('it can verify a creator', async (t) => {
   const umi = await createUmi();
   const asset = generateSigner(umi);
   const owner = generateSigner(umi);
+  const creator = generateSigner(umi);
 
   // And we initialize an asset with a creators extension.
   await initialize(umi, {
     asset,
     payer: umi.identity,
-    extension: creators([{ address: umi.identity.publicKey, share: 100 }]),
+    extension: creators([{ address: creator.publicKey, share: 100 }]),
   }).sendAndConfirm(umi);
 
   // And we create the asset.
@@ -39,7 +40,7 @@ test('it can verify a creator', async (t) => {
         type: ExtensionType.Creators,
         creators: [
           {
-            address: umi.identity.publicKey,
+            address: creator.publicKey,
             verified: false,
             share: 100,
           },
@@ -51,7 +52,7 @@ test('it can verify a creator', async (t) => {
   // When we verify the creator.
   await verify(umi, {
     asset: asset.publicKey,
-    creator: umi.identity,
+    creator,
   }).sendAndConfirm(umi);
 
   // Then the creator is verified.
@@ -61,7 +62,7 @@ test('it can verify a creator', async (t) => {
         type: ExtensionType.Creators,
         creators: [
           {
-            address: umi.identity.publicKey,
+            address: creator.publicKey,
             verified: true,
             share: 100,
           },

--- a/clients/js/asset/test/verify.test.ts
+++ b/clients/js/asset/test/verify.test.ts
@@ -180,12 +180,13 @@ test('it cannot verify a wrong creator', async (t) => {
   const umi = await createUmi();
   const asset = generateSigner(umi);
   const owner = generateSigner(umi);
+  const creator = generateSigner(umi).publicKey;
 
   // And we initialize an asset with a creators extension.
   await initialize(umi, {
     asset,
     payer: umi.identity,
-    extension: creators([{ address: umi.identity.publicKey, share: 100 }]),
+    extension: creators([{ address: creator, share: 100 }]),
   }).sendAndConfirm(umi);
 
   // And we create the asset.
@@ -202,7 +203,7 @@ test('it cannot verify a wrong creator', async (t) => {
         type: ExtensionType.Creators,
         creators: [
           {
-            address: umi.identity.publicKey,
+            address: creator,
             verified: false,
             share: 100,
           },
@@ -229,7 +230,7 @@ test('it cannot verify a wrong creator', async (t) => {
         type: ExtensionType.Creators,
         creators: [
           {
-            address: umi.identity.publicKey,
+            address: creator,
             verified: false,
             share: 100,
           },

--- a/programs/asset/program/src/processor/allocate.rs
+++ b/programs/asset/program/src/processor/allocate.rs
@@ -128,7 +128,12 @@ pub fn process_allocate(
 
         // validate the extension data
         let asset_data = &mut (*ctx.accounts.asset.data).borrow_mut();
-        on_create(extension_type, &mut asset_data[offset..offset + length]).map_err(|error| {
+        on_create(
+            extension_type,
+            &mut asset_data[offset..offset + length],
+            None,
+        )
+        .map_err(|error| {
             msg!("[ERROR] {}", error);
             AssetError::ExtensionDataInvalid
         })?;

--- a/programs/asset/program/src/processor/create.rs
+++ b/programs/asset/program/src/processor/create.rs
@@ -132,7 +132,12 @@ pub fn process_create(
             let length = extension.length() as usize;
 
             // validates the last extension found on the account
-            on_create(extension_type, &mut data[offset..offset + length]).map_err(|error| {
+            on_create(
+                extension_type,
+                &mut data[offset..offset + length],
+                Some(ctx.accounts.authority.key),
+            )
+            .map_err(|error| {
                 msg!("[ERROR] {}", error);
                 AssetError::ExtensionDataInvalid
             })?;

--- a/programs/asset/program/src/processor/update.rs
+++ b/programs/asset/program/src/processor/update.rs
@@ -158,6 +158,7 @@ pub fn process_update(
                 args.extension_type,
                 &mut account_data[start..start + current_length],
                 &mut (*buffer.data).borrow_mut()[Asset::LEN..Asset::LEN + header_length],
+                Some(ctx.accounts.authority.key),
             )
             .map_err(|error| {
                 msg!("[ERROR] {}", error);
@@ -176,6 +177,7 @@ pub fn process_update(
                     args.extension_type,
                     &mut account_data[start..start + current_length],
                     extension_data.as_mut_slice(),
+                    Some(ctx.accounts.authority.key),
                 )
                 .map_err(|error| {
                     msg!("[ERROR] {}", error);

--- a/programs/asset/program/src/processor/write.rs
+++ b/programs/asset/program/src/processor/write.rs
@@ -145,7 +145,12 @@ pub(crate) fn process_write(
 
         // validate the extension data
         let asset_data = &mut (*ctx.accounts.asset.data).borrow_mut();
-        on_create(extension_type, &mut asset_data[offset..offset + length]).map_err(|error| {
+        on_create(
+            extension_type,
+            &mut asset_data[offset..offset + length],
+            None,
+        )
+        .map_err(|error| {
             msg!("[ERROR] {}", error);
             AssetError::ExtensionDataInvalid
         })?;

--- a/programs/asset/types/src/extensions/grouping.rs
+++ b/programs/asset/types/src/extensions/grouping.rs
@@ -81,7 +81,7 @@ impl<'a> ExtensionDataMut<'a> for GroupingMut<'a> {
 }
 
 impl Lifecycle for GroupingMut<'_> {
-    fn on_create(&mut self) -> Result<(), super::Error> {
+    fn on_create(&mut self, _authority: Option<&Pubkey>) -> Result<(), super::Error> {
         if *self.size > 0 {
             Err(Error::InvalidGroupSize)
         } else {
@@ -89,7 +89,7 @@ impl Lifecycle for GroupingMut<'_> {
         }
     }
 
-    fn on_update(&mut self, other: &mut Self) -> Result<(), Error> {
+    fn on_update(&mut self, other: &mut Self, _authority: Option<&Pubkey>) -> Result<(), Error> {
         // size cannot be updated
         *other.size = *self.size;
 

--- a/programs/asset/types/src/extensions/proxy.rs
+++ b/programs/asset/types/src/extensions/proxy.rs
@@ -105,7 +105,7 @@ impl<'a> ExtensionDataMut<'a> for ProxyMut<'a> {
 }
 
 impl Lifecycle for ProxyMut<'_> {
-    fn on_update(&mut self, other: &mut Self) -> Result<(), Error> {
+    fn on_update(&mut self, other: &mut Self, _authority: Option<&Pubkey>) -> Result<(), Error> {
         if self.program != other.program || self.seeds != other.seeds || self.bump != other.bump {
             Err(Error::CannotModifyDerivationData)
         } else {


### PR DESCRIPTION
This PR adds the authority to `Lifecycle` callback so extensions can use the value when applicable. The authority is only passed on when it is a signer on the instruction triggering the callback.

Fixes #57 