### PR TITLE
Allow adding extensions on update

### DIFF
--- a/clients/js/asset/src/hooked/assetAccountData.ts
+++ b/clients/js/asset/src/hooked/assetAccountData.ts
@@ -57,7 +57,9 @@ export const getAssetAccountDataSerializer = (): Serializer<
       );
       const type = header.kind as ExtensionType;
 
-      if (ExtensionType[type]) {
+      if (type === ExtensionType.None) {
+        break;
+      } else if (ExtensionType[type]) {
         const [extension] = getExtensionSerializerFromType(type).deserialize(
           buffer.subarray(headerOffset, headerOffset + header.length)
         );

--- a/programs/asset/program/src/processor/create.rs
+++ b/programs/asset/program/src/processor/create.rs
@@ -131,7 +131,6 @@ pub fn process_create(
             let extension_type = extension.extension_type();
             let length = extension.length() as usize;
 
-            // validates the last extension found on the account
             on_create(
                 extension_type,
                 &mut data[offset..offset + length],

--- a/programs/asset/program/src/processor/update.rs
+++ b/programs/asset/program/src/processor/update.rs
@@ -225,9 +225,9 @@ pub fn process_update(
 
         if !update {
             require!(
-                boundary == account_data.len(),
+                offset == account_data.len(),
                 ProgramError::InvalidAccountData,
-                "account boundary mismatch"
+                "extension offset mismatch"
             );
             // drop the borrow to resize the account
             drop(account_data);

--- a/programs/asset/types/src/state/asset.rs
+++ b/programs/asset/types/src/state/asset.rs
@@ -174,10 +174,12 @@ impl Asset {
     /// `None` is returned.
     pub fn first_extension(data: &[u8]) -> Option<(&Extension, usize)> {
         if (Asset::LEN + Extension::LEN) <= data.len() {
-            return Some((
-                Extension::load(&data[Asset::LEN..]),
-                Asset::LEN + Extension::LEN,
-            ));
+            let extension = Extension::load(&data[Asset::LEN..]);
+
+            return match extension.try_extension_type() {
+                Ok(t) if t != ExtensionType::None => Some((extension, Asset::LEN + Extension::LEN)),
+                _ => None,
+            };
         }
 
         None


### PR DESCRIPTION
This PR enables adding extensions to an asset using the `update` instruction.