### PR TITLE
Rename field on attributes extension

### DIFF
--- a/clients/js/asset/src/generated/types/trait.ts
+++ b/clients/js/asset/src/generated/types/trait.ts
@@ -13,14 +13,14 @@ import {
   u8,
 } from '@metaplex-foundation/umi/serializers';
 
-export type Trait = { traitType: string; value: string };
+export type Trait = { name: string; value: string };
 
 export type TraitArgs = Trait;
 
 export function getTraitSerializer(): Serializer<TraitArgs, Trait> {
   return struct<Trait>(
     [
-      ['traitType', string({ size: u8() })],
+      ['name', string({ size: u8() })],
       ['value', string({ size: u8() })],
     ],
     { description: 'Trait' }

--- a/clients/js/asset/test/close.test.ts
+++ b/clients/js/asset/test/close.test.ts
@@ -12,7 +12,7 @@ test('it can close an uninitialized asset buffer account', async (t) => {
   await initialize(umi, {
     asset,
     payer: umi.identity,
-    extension: attributes([{ traitType: 'head', value: 'hat' }]),
+    extension: attributes([{ name: 'head', value: 'hat' }]),
   }).sendAndConfirm(umi);
 
   t.true(await umi.rpc.accountExists(asset.publicKey), 'asset exists');

--- a/clients/js/asset/test/create.test.ts
+++ b/clients/js/asset/test/create.test.ts
@@ -126,13 +126,13 @@ test('it can create a new asset with multiple extensions', async (t) => {
       {
         type: ExtensionType.Attributes,
         traits: [
-          { traitType: 'Attributes Count', value: '2' },
-          { traitType: 'Type', value: 'Dark' },
-          { traitType: 'Clothes', value: 'Purple Shirt' },
-          { traitType: 'Ears', value: 'None' },
-          { traitType: 'Mouth', value: 'None' },
-          { traitType: 'Eyes', value: 'None' },
-          { traitType: 'Hat', value: 'Blue Cap' },
+          { name: 'Attributes Count', value: '2' },
+          { name: 'Type', value: 'Dark' },
+          { name: 'Clothes', value: 'Purple Shirt' },
+          { name: 'Ears', value: 'None' },
+          { name: 'Mouth', value: 'None' },
+          { name: 'Eyes', value: 'None' },
+          { name: 'Hat', value: 'Blue Cap' },
         ],
       },
       {

--- a/clients/js/asset/test/create.test.ts
+++ b/clients/js/asset/test/create.test.ts
@@ -53,7 +53,7 @@ test('it can create a new asset with an extension', async (t) => {
   await initialize(umi, {
     asset,
     payer: umi.identity,
-    extension: attributes([{ traitType: 'head', value: 'hat' }]),
+    extension: attributes([{ name: 'head', value: 'hat' }]),
   }).sendAndConfirm(umi);
 
   // When we create a new asset.
@@ -75,7 +75,7 @@ test('it can create a new asset with an extension', async (t) => {
         type: ExtensionType.Attributes,
         traits: [
           {
-            traitType: 'head',
+            name: 'head',
             value: 'hat',
           },
         ],
@@ -98,13 +98,13 @@ test('it can create a new asset with multiple extensions', async (t) => {
     name: 'Digital Asset',
     extensions: [
       attributes([
-        { traitType: 'Attributes Count', value: '2' },
-        { traitType: 'Type', value: 'Dark' },
-        { traitType: 'Clothes', value: 'Purple Shirt' },
-        { traitType: 'Ears', value: 'None' },
-        { traitType: 'Mouth', value: 'None' },
-        { traitType: 'Eyes', value: 'None' },
-        { traitType: 'Hat', value: 'Blue Cap' },
+        { name: 'Attributes Count', value: '2' },
+        { name: 'Type', value: 'Dark' },
+        { name: 'Clothes', value: 'Purple Shirt' },
+        { name: 'Ears', value: 'None' },
+        { name: 'Mouth', value: 'None' },
+        { name: 'Eyes', value: 'None' },
+        { name: 'Hat', value: 'Blue Cap' },
       ]),
       links([
         {

--- a/clients/js/asset/test/initialize.test.ts
+++ b/clients/js/asset/test/initialize.test.ts
@@ -12,7 +12,7 @@ test('it can initialize a new asset with an extension', async (t) => {
   await initialize(umi, {
     asset,
     payer: umi.identity,
-    extension: attributes([{ traitType: 'head', value: 'hat' }]),
+    extension: attributes([{ name: 'head', value: 'hat' }]),
   }).sendAndConfirm(umi);
 
   // Then the asset account was created.
@@ -28,14 +28,14 @@ test('it cannot initialize the same extension', async (t) => {
   await initialize(umi, {
     asset,
     payer: umi.identity,
-    extension: attributes([{ traitType: 'head', value: 'hat' }]),
+    extension: attributes([{ name: 'head', value: 'hat' }]),
   }).sendAndConfirm(umi);
 
   // When we try to initialize the same extension again.
   const promise = initialize(umi, {
     asset,
     payer: umi.identity,
-    extension: attributes([{ traitType: 'power', value: 'wizard' }]),
+    extension: attributes([{ name: 'power', value: 'wizard' }]),
   }).sendAndConfirm(umi);
 
   await t.throwsAsync(promise, { message: /Asset already initialized/ });
@@ -50,7 +50,7 @@ test('it can initialize a new asset with multiple extensions', async (t) => {
   await initialize(umi, {
     asset,
     payer: umi.identity,
-    extension: attributes([{ traitType: 'head', value: 'hat' }]),
+    extension: attributes([{ name: 'head', value: 'hat' }]),
   }).sendAndConfirm(umi);
 
   t.true(await umi.rpc.accountExists(asset.publicKey), 'asset exists');

--- a/clients/js/asset/test/mint.test.ts
+++ b/clients/js/asset/test/mint.test.ts
@@ -53,7 +53,7 @@ test('it can mint an asset with an extension', async (t) => {
     owner: owner.publicKey,
     payer: umi.identity,
     name: 'Digital Asset',
-    extensions: [attributes([{ traitType: 'head', value: 'hat' }])],
+    extensions: [attributes([{ name: 'head', value: 'hat' }])],
   }).sendAndConfirm(umi);
 
   // Then an asset was created with the correct data.
@@ -68,7 +68,7 @@ test('it can mint an asset with an extension', async (t) => {
         type: ExtensionType.Attributes,
         traits: [
           {
-            traitType: 'head',
+            name: 'head',
             value: 'hat',
           },
         ],
@@ -99,13 +99,13 @@ test('it can mint a new asset with multiple extensions', async (t) => {
     name: 'SMB #1355 (test)',
     extensions: [
       attributes([
-        { traitType: 'Attributes Count', value: '2' },
-        { traitType: 'Type', value: 'Skeleton' },
-        { traitType: 'Clothes', value: 'Orange Jacket' },
-        { traitType: 'Ears', value: 'None' },
-        { traitType: 'Mouth', value: 'None' },
-        { traitType: 'Eyes', value: 'None' },
-        { traitType: 'Hat', value: 'Crown' },
+        { name: 'Attributes Count', value: '2' },
+        { name: 'Type', value: 'Skeleton' },
+        { name: 'Clothes', value: 'Orange Jacket' },
+        { name: 'Ears', value: 'None' },
+        { name: 'Mouth', value: 'None' },
+        { name: 'Eyes', value: 'None' },
+        { name: 'Hat', value: 'Crown' },
       ]),
       creators([
         {

--- a/clients/js/asset/test/remove.test.ts
+++ b/clients/js/asset/test/remove.test.ts
@@ -32,9 +32,9 @@ test('it can remove an extension from an asset', async (t) => {
     payer: umi.identity,
     extensions: [
       attributes([
-        { traitType: 'Type', value: 'Dark' },
-        { traitType: 'Clothes', value: 'Purple Shirt' },
-        { traitType: 'Ears', value: 'None' },
+        { name: 'Type', value: 'Dark' },
+        { name: 'Clothes', value: 'Purple Shirt' },
+        { name: 'Ears', value: 'None' },
       ]),
       metadata({
         symbol: 'MAD',
@@ -49,9 +49,9 @@ test('it can remove an extension from an asset', async (t) => {
       {
         type: ExtensionType.Attributes,
         traits: [
-          { traitType: 'Type', value: 'Dark' },
-          { traitType: 'Clothes', value: 'Purple Shirt' },
-          { traitType: 'Ears', value: 'None' },
+          { name: 'Type', value: 'Dark' },
+          { name: 'Clothes', value: 'Purple Shirt' },
+          { name: 'Ears', value: 'None' },
         ],
       },
       {
@@ -115,9 +115,9 @@ test('it can remove the first extension of an asset', async (t) => {
         },
       ]),
       attributes([
-        { traitType: 'Type', value: 'Dark' },
-        { traitType: 'Clothes', value: 'Purple Shirt' },
-        { traitType: 'Ears', value: 'None' },
+        { name: 'Type', value: 'Dark' },
+        { name: 'Clothes', value: 'Purple Shirt' },
+        { name: 'Ears', value: 'None' },
       ]),
     ],
   }).sendAndConfirm(umi);
@@ -158,9 +158,9 @@ test('it can remove the first extension of an asset', async (t) => {
       {
         type: ExtensionType.Attributes,
         traits: [
-          { traitType: 'Type', value: 'Dark' },
-          { traitType: 'Clothes', value: 'Purple Shirt' },
-          { traitType: 'Ears', value: 'None' },
+          { name: 'Type', value: 'Dark' },
+          { name: 'Clothes', value: 'Purple Shirt' },
+          { name: 'Ears', value: 'None' },
         ],
       },
     ],
@@ -187,9 +187,9 @@ test('it can remove the last extension of an asset', async (t) => {
         },
       ]),
       attributes([
-        { traitType: 'Type', value: 'Dark' },
-        { traitType: 'Clothes', value: 'Purple Shirt' },
-        { traitType: 'Ears', value: 'None' },
+        { name: 'Type', value: 'Dark' },
+        { name: 'Clothes', value: 'Purple Shirt' },
+        { name: 'Ears', value: 'None' },
       ]),
     ],
   }).sendAndConfirm(umi);
@@ -369,9 +369,9 @@ test('it cannot remove a non-existing extension', async (t) => {
     payer: umi.identity,
     extensions: [
       attributes([
-        { traitType: 'Type', value: 'Dark' },
-        { traitType: 'Clothes', value: 'Purple Shirt' },
-        { traitType: 'Ears', value: 'None' },
+        { name: 'Type', value: 'Dark' },
+        { name: 'Clothes', value: 'Purple Shirt' },
+        { name: 'Ears', value: 'None' },
       ]),
       metadata({
         symbol: 'MAD',

--- a/clients/js/asset/test/remove.test.ts
+++ b/clients/js/asset/test/remove.test.ts
@@ -81,9 +81,9 @@ test('it can remove an extension from an asset', async (t) => {
       {
         type: ExtensionType.Attributes,
         traits: [
-          { traitType: 'Type', value: 'Dark' },
-          { traitType: 'Clothes', value: 'Purple Shirt' },
-          { traitType: 'Ears', value: 'None' },
+          { name: 'Type', value: 'Dark' },
+          { name: 'Clothes', value: 'Purple Shirt' },
+          { name: 'Ears', value: 'None' },
         ],
       },
       {
@@ -136,9 +136,9 @@ test('it can remove the first extension of an asset', async (t) => {
       {
         type: ExtensionType.Attributes,
         traits: [
-          { traitType: 'Type', value: 'Dark' },
-          { traitType: 'Clothes', value: 'Purple Shirt' },
-          { traitType: 'Ears', value: 'None' },
+          { name: 'Type', value: 'Dark' },
+          { name: 'Clothes', value: 'Purple Shirt' },
+          { name: 'Ears', value: 'None' },
         ],
       },
     ],
@@ -208,9 +208,9 @@ test('it can remove the last extension of an asset', async (t) => {
       {
         type: ExtensionType.Attributes,
         traits: [
-          { traitType: 'Type', value: 'Dark' },
-          { traitType: 'Clothes', value: 'Purple Shirt' },
-          { traitType: 'Ears', value: 'None' },
+          { name: 'Type', value: 'Dark' },
+          { name: 'Clothes', value: 'Purple Shirt' },
+          { name: 'Ears', value: 'None' },
         ],
       },
     ],
@@ -386,9 +386,9 @@ test('it cannot remove a non-existing extension', async (t) => {
       {
         type: ExtensionType.Attributes,
         traits: [
-          { traitType: 'Type', value: 'Dark' },
-          { traitType: 'Clothes', value: 'Purple Shirt' },
-          { traitType: 'Ears', value: 'None' },
+          { name: 'Type', value: 'Dark' },
+          { name: 'Clothes', value: 'Purple Shirt' },
+          { name: 'Ears', value: 'None' },
         ],
       },
       {

--- a/clients/js/asset/test/update.test.ts
+++ b/clients/js/asset/test/update.test.ts
@@ -119,9 +119,9 @@ test('it can update the extension of an asset', async (t) => {
     asset,
     payer: umi.identity,
     extension: attributes([
-      { traitType: 'Type', value: 'Dark' },
-      { traitType: 'Clothes', value: 'Purple Shirt' },
-      { traitType: 'Ears', value: 'None' },
+      { name: 'Type', value: 'Dark' },
+      { name: 'Clothes', value: 'Purple Shirt' },
+      { name: 'Ears', value: 'None' },
     ]),
   }).sendAndConfirm(umi);
 
@@ -137,9 +137,9 @@ test('it can update the extension of an asset', async (t) => {
       {
         type: ExtensionType.Attributes,
         traits: [
-          { traitType: 'Type', value: 'Dark' },
-          { traitType: 'Clothes', value: 'Purple Shirt' },
-          { traitType: 'Ears', value: 'None' },
+          { name: 'Type', value: 'Dark' },
+          { name: 'Clothes', value: 'Purple Shirt' },
+          { name: 'Ears', value: 'None' },
         ],
       },
     ],
@@ -149,7 +149,7 @@ test('it can update the extension of an asset', async (t) => {
   await update(umi, {
     asset: asset.publicKey,
     payer: umi.identity,
-    extension: attributes([{ traitType: 'Clothes', value: 'Purple Shirt' }]),
+    extension: attributes([{ name: 'Clothes', value: 'Purple Shirt' }]),
   }).sendAndConfirm(umi);
 
   // Then the extension is updated.
@@ -157,7 +157,7 @@ test('it can update the extension of an asset', async (t) => {
     extensions: [
       {
         type: ExtensionType.Attributes,
-        traits: [{ traitType: 'Clothes', value: 'Purple Shirt' }],
+        traits: [{ name: 'Clothes', value: 'Purple Shirt' }],
       },
     ],
   });
@@ -174,9 +174,9 @@ test('it can update the extension of an asset with multiple extensions', async (
     asset,
     payer: umi.identity,
     extension: attributes([
-      { traitType: 'Type', value: 'Dark' },
-      { traitType: 'Clothes', value: 'Purple Shirt' },
-      { traitType: 'Ears', value: 'None' },
+      { name: 'Type', value: 'Dark' },
+      { name: 'Clothes', value: 'Purple Shirt' },
+      { name: 'Ears', value: 'None' },
     ]),
   }).sendAndConfirm(umi);
 
@@ -225,7 +225,7 @@ test('it can update the extension of an asset with multiple extensions', async (
   await update(umi, {
     asset: asset.publicKey,
     payer: umi.identity,
-    extension: attributes([{ traitType: 'Clothes', value: 'Purple Shirt' }]),
+    extension: attributes([{ name: 'Clothes', value: 'Purple Shirt' }]),
   }).sendAndConfirm(umi);
 
   // Then the extension is updated.
@@ -258,7 +258,7 @@ test('it can extend the length of an extension', async (t) => {
   await initialize(umi, {
     asset,
     payer: umi.identity,
-    extension: attributes([{ traitType: 'Type', value: 'Dark' }]),
+    extension: attributes([{ name: 'Type', value: 'Dark' }]),
   }).sendAndConfirm(umi);
 
   // And we create a new asset.
@@ -272,7 +272,7 @@ test('it can extend the length of an extension', async (t) => {
     extensions: [
       {
         type: ExtensionType.Attributes,
-        traits: [{ traitType: 'Type', value: 'Dark' }],
+        traits: [{ name: 'Type', value: 'Dark' }],
       },
     ],
   });
@@ -282,9 +282,9 @@ test('it can extend the length of an extension', async (t) => {
     asset: asset.publicKey,
     payer: umi.identity,
     extension: attributes([
-      { traitType: 'Type', value: 'Dark' },
-      { traitType: 'Clothes', value: 'Purple Shirt' },
-      { traitType: 'Ears', value: 'None' },
+      { name: 'Type', value: 'Dark' },
+      { name: 'Clothes', value: 'Purple Shirt' },
+      { name: 'Ears', value: 'None' },
     ]),
   }).sendAndConfirm(umi);
 
@@ -294,9 +294,9 @@ test('it can extend the length of an extension', async (t) => {
       {
         type: ExtensionType.Attributes,
         traits: [
-          { traitType: 'Type', value: 'Dark' },
-          { traitType: 'Clothes', value: 'Purple Shirt' },
-          { traitType: 'Ears', value: 'None' },
+          { name: 'Type', value: 'Dark' },
+          { name: 'Clothes', value: 'Purple Shirt' },
+          { name: 'Ears', value: 'None' },
         ],
       },
     ],
@@ -388,9 +388,9 @@ test('it can update an asset to add an extension', async (t) => {
     asset: asset.publicKey,
     payer: umi.identity,
     extension: attributes([
-      { traitType: 'Type', value: 'Dark' },
-      { traitType: 'Clothes', value: 'Purple Shirt' },
-      { traitType: 'Ears', value: 'None' },
+      { name: 'Type', value: 'Dark' },
+      { name: 'Clothes', value: 'Purple Shirt' },
+      { name: 'Ears', value: 'None' },
     ]),
   }).sendAndConfirm(umi);
 
@@ -400,9 +400,9 @@ test('it can update an asset to add an extension', async (t) => {
       {
         type: ExtensionType.Attributes,
         traits: [
-          { traitType: 'Type', value: 'Dark' },
-          { traitType: 'Clothes', value: 'Purple Shirt' },
-          { traitType: 'Ears', value: 'None' },
+          { name: 'Type', value: 'Dark' },
+          { name: 'Clothes', value: 'Purple Shirt' },
+          { name: 'Ears', value: 'None' },
         ],
       },
     ],
@@ -430,9 +430,9 @@ test('it can update an asset to add multiple extensions', async (t) => {
     asset: asset.publicKey,
     payer: umi.identity,
     extension: attributes([
-      { traitType: 'Type', value: 'Dark' },
-      { traitType: 'Clothes', value: 'Purple Shirt' },
-      { traitType: 'Ears', value: 'None' },
+      { name: 'Type', value: 'Dark' },
+      { name: 'Clothes', value: 'Purple Shirt' },
+      { name: 'Ears', value: 'None' },
     ]),
   }).sendAndConfirm(umi);
 
@@ -441,9 +441,9 @@ test('it can update an asset to add multiple extensions', async (t) => {
       {
         type: ExtensionType.Attributes,
         traits: [
-          { traitType: 'Type', value: 'Dark' },
-          { traitType: 'Clothes', value: 'Purple Shirt' },
-          { traitType: 'Ears', value: 'None' },
+          { name: 'Type', value: 'Dark' },
+          { name: 'Clothes', value: 'Purple Shirt' },
+          { name: 'Ears', value: 'None' },
         ],
       },
     ],

--- a/clients/js/asset/test/update.test.ts
+++ b/clients/js/asset/test/update.test.ts
@@ -204,9 +204,9 @@ test('it can update the extension of an asset with multiple extensions', async (
       {
         type: ExtensionType.Attributes,
         traits: [
-          { traitType: 'Type', value: 'Dark' },
-          { traitType: 'Clothes', value: 'Purple Shirt' },
-          { traitType: 'Ears', value: 'None' },
+          { name: 'Type', value: 'Dark' },
+          { name: 'Clothes', value: 'Purple Shirt' },
+          { name: 'Ears', value: 'None' },
         ],
       },
       {
@@ -233,7 +233,7 @@ test('it can update the extension of an asset with multiple extensions', async (
     extensions: [
       {
         type: ExtensionType.Attributes,
-        traits: [{ traitType: 'Clothes', value: 'Purple Shirt' }],
+        traits: [{ name: 'Clothes', value: 'Purple Shirt' }],
       },
       {
         type: ExtensionType.Links,
@@ -467,9 +467,9 @@ test('it can update an asset to add multiple extensions', async (t) => {
       {
         type: ExtensionType.Attributes,
         traits: [
-          { traitType: 'Type', value: 'Dark' },
-          { traitType: 'Clothes', value: 'Purple Shirt' },
-          { traitType: 'Ears', value: 'None' },
+          { name: 'Type', value: 'Dark' },
+          { name: 'Clothes', value: 'Purple Shirt' },
+          { name: 'Ears', value: 'None' },
         ],
       },
       {

--- a/clients/rust/asset/src/generated/types/trait.rs
+++ b/clients/rust/asset/src/generated/types/trait.rs
@@ -12,6 +12,6 @@ use kaigan::types::U8PrefixString;
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Trait {
-    pub trait_type: U8PrefixString,
+    pub name: U8PrefixString,
     pub value: U8PrefixString,
 }

--- a/configs/kinobi-asset.cjs
+++ b/configs/kinobi-asset.cjs
@@ -483,7 +483,6 @@ kinobi.accept(
         ".prettierrc.json"
       )),
       internalNodes: [
-        "allocate",
         "approve",
         "burn",
         "create",

--- a/configs/kinobi-asset.cjs
+++ b/configs/kinobi-asset.cjs
@@ -187,7 +187,7 @@ kinobi.update(
               name: "trait",
               type: k.structTypeNode([
                 k.structFieldTypeNode({
-                  name: "traitType",
+                  name: "name",
                   type: k.stringTypeNode({
                     size: k.prefixedSizeNode(k.numberTypeNode("u8")),
                   }),
@@ -483,6 +483,7 @@ kinobi.accept(
         ".prettierrc.json"
       )),
       internalNodes: [
+        "allocate",
         "approve",
         "burn",
         "create",


### PR DESCRIPTION
This PR renames the `traitType` field on the attributes extension to `name`. This change is backwards compatible and only affects the client code.