### PR TITLE
Add default interface processor

### DIFF
--- a/clients/js/proxy/src/index.ts
+++ b/clients/js/proxy/src/index.ts
@@ -1,2 +1,3 @@
 export * from './generated';
+export * from './pda';
 export * from './plugin';

--- a/clients/js/proxy/test/approve.test.ts
+++ b/clients/js/proxy/test/approve.test.ts
@@ -1,0 +1,53 @@
+import { generateSigner } from '@metaplex-foundation/umi';
+import {
+  Asset,
+  DelegateRole,
+  ExtensionType,
+  approve,
+  delegateInput,
+  fetchAsset,
+  getExtension,
+} from '@nifty-oss/asset';
+import test from 'ava';
+import { findProxiedAssetPda } from '../src';
+import { create } from '../src';
+import { createUmi } from './_setup';
+
+test('it can set a delegate through the proxy program', async (t) => {
+  // Given a Umi instance and a new signer.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+
+  // And a stub signer.
+  const stub = generateSigner(umi);
+
+  // When we create a new proxied asset.
+  await create(umi, {
+    stub,
+    owner: owner.publicKey,
+    payer: umi.identity,
+    name: 'Proxied Asset',
+  }).sendAndConfirm(umi);
+
+  const [address] = findProxiedAssetPda(umi, { stub: stub.publicKey });
+  let asset = await fetchAsset(umi, address);
+  const proxy = getExtension(asset, ExtensionType.Proxy);
+
+  // When we approve a delegate.
+  const delegate = generateSigner(umi).publicKey;
+  await approve(umi, {
+    asset: address,
+    owner,
+    delegate,
+    delegateInput: delegateInput('Some', { roles: [DelegateRole.Transfer] }),
+    proxy: proxy?.program,
+  }).sendAndConfirm(umi);
+
+  // Then the delegate is set.
+  t.like(await fetchAsset(umi, address), <Asset>{
+    delegate: {
+      address: delegate,
+      roles: [DelegateRole.Transfer],
+    },
+  });
+});

--- a/programs/asset/interface/src/lib.rs
+++ b/programs/asset/interface/src/lib.rs
@@ -1,5 +1,6 @@
 mod generated;
 mod interface;
+mod processor;
 
 pub use interface::*;
 use solana_program::pubkey::Pubkey;

--- a/programs/asset/interface/src/processor.rs
+++ b/programs/asset/interface/src/processor.rs
@@ -1,0 +1,124 @@
+use solana_program::{
+    account_info::AccountInfo,
+    entrypoint::ProgramResult,
+    instruction::{AccountMeta, Instruction},
+    program::invoke_signed,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+use crate::Interface;
+
+/// Fetches the data for a proxy asset.
+///
+/// This macro is used to fetch the data from the proxy extension of an asset.
+///
+/// # Arguments
+///
+/// 1. `data` - expression representing the account data.
+/// 2. `signer` - identifier to store the signer seeds.
+/// 3. `authority` - identifier to store the authority pubkey.
+/// 4. `program` - (optional) identifier to store the program pubkey.
+/// 5. `remaining` - (optional) expression representing the remaining accounts array.
+#[macro_export]
+macro_rules! fetch_proxy_data {
+    ( $data:expr, $signer:ident, $authority:ident ) => {
+        // proxy
+        let __proxy = $crate::state::Asset::get::<$crate::extensions::Proxy>($data)
+            .ok_or(solana_program::program_error::ProgramError::InvalidAccountData)?;
+
+        let __seeds = *__proxy.seeds;
+        let $signer = [__seeds.as_ref(), &[*__proxy.bump]];
+
+        let $authority = if let Some(authority) = __proxy.authority.value() {
+            Some(*authority)
+        } else {
+            None
+        };
+    };
+
+    ( $data:expr, $signer:ident, $authority:ident, $program:ident, $remaining:expr ) => {
+        fetch_proxy_data!($data, $signer, $authority);
+
+        let $program = $remaining
+            .iter()
+            .find(|account| {
+                account.key
+                    == &solana_program::pubkey!("AssetGtQBTSgm5s91d1RAQod5JmaZiJDxqsgtqrZud73")
+            })
+            .ok_or(solana_program::program_error::ProgramError::NotEnoughAccountKeys)?;
+    };
+}
+
+/// Logs the name of the instruction.
+///
+/// The macro use the first byte of the instruction data to determine
+/// the name of the instruction.
+macro_rules! log_instruction_name {
+    ( $instruction_data:expr ) => {{
+        if $instruction_data.is_empty() {
+            return Err(solana_program::program_error::ProgramError::InvalidInstructionData);
+        }
+
+        let name = match $instruction_data[0] {
+            0 => "Close",
+            1 => "Burn",
+            2 => "Create",
+            3 => "Approve",
+            4 => "Allocate",
+            5 => "Lock",
+            6 => "Revoke",
+            7 => "Transfer",
+            8 => "Unlock",
+            9 => "Unverify",
+            10 => "Update",
+            11 => "Verify",
+            12 => "Write",
+            13 => "Group",
+            14 => "Ungroup",
+            15 => "Handover",
+            16 => "Remove",
+            _ => return Err(solana_program::program_error::ProgramError::InvalidInstructionData),
+        };
+
+        solana_program::msg!("Interface: {}", name);
+    }};
+}
+
+impl Interface {
+    /// Processes the instruction for the asset program.
+    pub fn process_instruction<'a>(
+        _program_id: &'a Pubkey,
+        accounts: &'a [AccountInfo<'a>],
+        instruction_data: &[u8],
+    ) -> ProgramResult {
+        log_instruction_name!(instruction_data);
+
+        let asset = accounts.first().ok_or(ProgramError::NotEnoughAccountKeys)?;
+        let data = (*asset.data).borrow();
+        fetch_proxy_data!(&data, signer, _authority);
+        // drop the data before invoking the CPI
+        drop(data);
+
+        let mut account_metas = Vec::with_capacity(accounts.len());
+        accounts.iter().for_each(|account| {
+            account_metas.push(AccountMeta {
+                pubkey: *account.key,
+                is_signer: account.is_signer,
+                is_writable: account.is_writable,
+            });
+        });
+        // the asset account must be a signer
+        account_metas.first_mut().unwrap().is_signer = true;
+
+        invoke_signed(
+            &Instruction {
+                accounts: account_metas,
+                data: instruction_data.to_vec(),
+                program_id: solana_program::pubkey!("AssetGtQBTSgm5s91d1RAQod5JmaZiJDxqsgtqrZud73"),
+            },
+            accounts,
+            &[&signer],
+        )
+    }
+}

--- a/programs/proxy/src/processor/transfer.rs
+++ b/programs/proxy/src/processor/transfer.rs
@@ -1,6 +1,7 @@
 use nifty_asset_interface::{
     accounts::TransferAccounts,
     extensions::{Attributes, AttributesBuilder, BlobBuilder, ExtensionBuilder},
+    fetch_proxy_data,
     instructions::{TransferCpiBuilder, UpdateCpiBuilder},
     state::Asset,
     types::ExtensionInput,
@@ -11,11 +12,7 @@ use solana_program::{
     pubkey::Pubkey, sysvar::Sysvar,
 };
 
-use crate::{
-    fetch_signer_and_authority,
-    processor::{CONTENT_TYPE, IMAGE},
-    require,
-};
+use crate::processor::{CONTENT_TYPE, IMAGE};
 
 pub fn process_transfer<'a>(
     _program_id: &Pubkey,
@@ -24,7 +21,13 @@ pub fn process_transfer<'a>(
     // account validation happends on the CPI
 
     let data = (*ctx.accounts.asset.data).borrow();
-    fetch_signer_and_authority!(signer, _authority, nifty_asset_program, ctx, &data);
+    fetch_proxy_data!(
+        &data,
+        signer,
+        _authority,
+        nifty_asset_program,
+        ctx.remaining_accounts
+    );
 
     // update the transfers "counter"
 

--- a/programs/proxy/src/processor/update.rs
+++ b/programs/proxy/src/processor/update.rs
@@ -1,9 +1,9 @@
 use nifty_asset_interface::{
-    accounts::UpdateAccounts, instructions::UpdateCpiBuilder, UpdateInput,
+    accounts::UpdateAccounts, fetch_proxy_data, instructions::UpdateCpiBuilder, UpdateInput,
 };
 use solana_program::{entrypoint::ProgramResult, msg, program_error::ProgramError, pubkey::Pubkey};
 
-use crate::{fetch_signer_and_authority, require};
+use crate::require;
 
 pub fn process_update<'a>(
     _program_id: &Pubkey,
@@ -14,7 +14,13 @@ pub fn process_update<'a>(
     // have the authority to perform the update
 
     let data = (*ctx.accounts.asset.data).borrow();
-    fetch_signer_and_authority!(signer, authority, nifty_asset_program, ctx, &data);
+    fetch_proxy_data!(
+        &data,
+        signer,
+        authority,
+        nifty_asset_program,
+        ctx.remaining_accounts
+    );
 
     require!(
         ctx.accounts.authority.is_signer,


### PR DESCRIPTION
This PR adds a default processor for interface instructions. Proxy programs can choose which instructions to override or block, and then forward the remaining instructions to the interface processor.