### PR TITLE
Use nitrate entrypoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,7 @@ dependencies = [
  "borsh 0.10.3",
  "bytemuck",
  "nifty-asset-types",
+ "nitrate",
  "num-derive 0.3.3",
  "num-traits",
  "shank",
@@ -2182,6 +2183,37 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "thiserror",
+]
+
+[[package]]
+name = "nitrate"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd91428ad6fe469b6bd1df7409dfcaa6ebbb9e5a682715c8c08d0590a001205"
+dependencies = [
+ "nitrate-macro",
+ "nitrate-program",
+]
+
+[[package]]
+name = "nitrate-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c5707c776fbcde8b8a20f97c7983c502b23868e9159064ef56b704a260889fa"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "nitrate-program"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de6e5eeb68694d9aae8562be35dfee2de60d2a603ccc5d0fac89643629d1ec3"
+dependencies = [
+ "rustversion",
+ "solana-program",
 ]
 
 [[package]]

--- a/configs/scripts/program/clean.sh
+++ b/configs/scripts/program/clean.sh
@@ -6,6 +6,7 @@ OUTPUT="./programs/.bin"
 cd $(dirname $(dirname $(dirname ${SCRIPT_DIR})))
 
 rm -rf $OUTPUT
+rm -rf ./target
 
 if [ -z ${PROGRAMS+x} ]; then
     PROGRAMS="$(cat .github/.env | grep "PROGRAMS" | cut -d '=' -f 2)"

--- a/programs/asset/program/Cargo.toml
+++ b/programs/asset/program/Cargo.toml
@@ -18,6 +18,7 @@ borsh = "^0.10"
 bytemuck = "1.14"
 shank = "0.3.0"
 nifty-asset-types = { path = "../types" }
+nitrate = "0.1.0"
 num-derive = "^0.3"
 num-traits = "^0.2"
 solana-security-txt = "1.1.1"

--- a/programs/asset/program/src/entrypoint.rs
+++ b/programs/asset/program/src/entrypoint.rs
@@ -1,6 +1,5 @@
+use nitrate::{entrypoint, program::AccountInfo};
 use solana_program::{
-    account_info::AccountInfo,
-    entrypoint,
     entrypoint::ProgramResult,
     program_error::{PrintProgramError, ProgramError},
     pubkey::Pubkey,
@@ -8,10 +7,11 @@ use solana_program::{
 
 use crate::{error::AssetError, processor};
 
-entrypoint!(process_instruction);
+entrypoint!(process_instruction, 7);
+
 fn process_instruction<'a>(
     program_id: &'a Pubkey,
-    accounts: &'a [AccountInfo<'a>],
+    accounts: &'a [AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
     if let Err(error) = processor::process_instruction(program_id, accounts, instruction_data) {

--- a/programs/asset/program/src/instruction.rs
+++ b/programs/asset/program/src/instruction.rs
@@ -3,9 +3,10 @@ use nifty_asset_types::{
     extensions::ExtensionType,
     state::{DelegateRole, Standard},
 };
-use shank::{ShankContext, ShankInstruction};
+use nitrate::Accounts;
+use shank::ShankInstruction;
 
-#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, ShankContext, ShankInstruction)]
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, ShankInstruction, Accounts)]
 #[rustfmt::skip]
 pub enum Instruction {
     /// Closes an uninitialized asset (buffer) account.

--- a/programs/asset/program/src/processor/allocate.rs
+++ b/programs/asset/program/src/processor/allocate.rs
@@ -3,16 +3,16 @@ use nifty_asset_types::{
     podded::ZeroCopy,
     state::{Asset, Discriminator},
 };
+use nitrate::program::system;
 use solana_program::{
-    entrypoint::ProgramResult, msg, program::invoke, program_error::ProgramError,
-    program_memory::sol_memcpy, pubkey::Pubkey, rent::Rent, system_instruction, system_program,
-    sysvar::Sysvar,
+    entrypoint::ProgramResult, msg, program_error::ProgramError, program_memory::sol_memcpy,
+    pubkey::Pubkey, rent::Rent, system_program, sysvar::Sysvar,
 };
 
 use crate::{
     error::AssetError,
     instruction::{
-        accounts::{AllocateAccounts, Context},
+        accounts::{Allocate, Context},
         AllocateInput,
     },
     processor::resize,
@@ -29,13 +29,13 @@ use crate::{
 #[inline(always)]
 pub fn process_allocate(
     program_id: &Pubkey,
-    ctx: Context<AllocateAccounts>,
+    ctx: Context<Allocate>,
     args: AllocateInput,
 ) -> ProgramResult {
     // account validation
 
     require!(
-        ctx.accounts.asset.is_signer,
+        ctx.accounts.asset.is_signer(),
         ProgramError::MissingRequiredSignature,
         "asset"
     );
@@ -46,7 +46,7 @@ pub fn process_allocate(
         (false, Asset::LEN)
     } else {
         require!(
-            ctx.accounts.asset.owner == program_id,
+            ctx.accounts.asset.owner() == program_id,
             ProgramError::IllegalOwner,
             "asset"
         );
@@ -57,7 +57,7 @@ pub fn process_allocate(
             "asset"
         );
 
-        let data = (*ctx.accounts.asset.data).borrow();
+        let data = ctx.accounts.asset.try_borrow_data()?;
 
         // make sure that the asset is not already initialized
         require!(
@@ -117,7 +117,7 @@ pub fn process_allocate(
             length
         );
     } else {
-        let asset_data = (*ctx.accounts.asset.data).borrow();
+        let asset_data = ctx.accounts.asset.try_borrow_data()?;
         let (extension, offset) =
             Asset::last_extension(&asset_data).ok_or(AssetError::ExtensionNotFound)?;
 
@@ -127,7 +127,7 @@ pub fn process_allocate(
         drop(asset_data);
 
         // validate the extension data
-        let asset_data = &mut (*ctx.accounts.asset.data).borrow_mut();
+        let asset_data = &mut ctx.accounts.asset.try_borrow_mut_data()?;
         on_create(
             extension_type,
             &mut asset_data[offset..offset + length],
@@ -148,7 +148,7 @@ pub fn process_allocate(
 }
 
 #[inline(always)]
-fn create_account(ctx: &Context<AllocateAccounts>, space: usize) -> ProgramResult {
+fn create_account(ctx: &Context<Allocate>, space: usize) -> ProgramResult {
     let payer = {
         require!(
             ctx.accounts.payer.is_some(),
@@ -160,7 +160,7 @@ fn create_account(ctx: &Context<AllocateAccounts>, space: usize) -> ProgramResul
     };
 
     require!(
-        payer.is_signer,
+        payer.is_signer(),
         ProgramError::MissingRequiredSignature,
         "payer"
     );
@@ -176,26 +176,25 @@ fn create_account(ctx: &Context<AllocateAccounts>, space: usize) -> ProgramResul
     };
 
     require!(
-        system_program.key == &system_program::ID,
+        system_program.key() == &system_program::ID,
         ProgramError::IncorrectProgramId,
         "system_program"
     );
 
-    invoke(
-        &system_instruction::create_account(
-            payer.key,
-            ctx.accounts.asset.key,
-            Rent::get()?.minimum_balance(space),
-            space as u64,
-            &crate::ID,
-        ),
-        &[payer.clone(), ctx.accounts.asset.clone()],
-    )
+    system::create_account(
+        payer,
+        ctx.accounts.asset,
+        Rent::get()?.minimum_balance(space),
+        space as u64,
+        &crate::ID,
+    );
+
+    Ok(())
 }
 
 #[inline(always)]
 fn save_extension_data(
-    ctx: &Context<AllocateAccounts>,
+    ctx: &Context<Allocate>,
     args: &crate::instruction::ExtensionInput,
     exists: bool,
     offset: usize,
@@ -235,7 +234,7 @@ fn save_extension_data(
         )?;
     }
 
-    let asset_data = &mut (*ctx.accounts.asset.data).borrow_mut();
+    let asset_data = &mut ctx.accounts.asset.try_borrow_mut_data()?;
     let extension = Extension::load_mut(&mut asset_data[offset..offset + Extension::LEN]);
 
     extension.set_extension_type(args.extension_type);

--- a/programs/asset/program/src/processor/close.rs
+++ b/programs/asset/program/src/processor/close.rs
@@ -3,7 +3,7 @@ use solana_program::{entrypoint::ProgramResult, program_error::ProgramError, pub
 
 use crate::{
     error::AssetError,
-    instruction::accounts::{CloseAccounts, Context},
+    instruction::accounts::{Close, Context},
     require,
     utils::close_program_account,
 };
@@ -14,22 +14,22 @@ use crate::{
 ///
 ///   0. `[writable, signer]` buffer
 ///   1. `[writable]` recipient
-pub fn process_close(program_id: &Pubkey, ctx: Context<CloseAccounts>) -> ProgramResult {
+pub fn process_close(program_id: &Pubkey, ctx: Context<Close>) -> ProgramResult {
     // account validation
 
     require!(
-        ctx.accounts.buffer.is_signer,
+        ctx.accounts.buffer.is_signer(),
         ProgramError::MissingRequiredSignature,
         "buffer"
     );
 
     require!(
-        ctx.accounts.buffer.owner == program_id,
+        ctx.accounts.buffer.owner() == program_id,
         ProgramError::IllegalOwner,
         "buffer"
     );
 
-    let data = (*ctx.accounts.buffer.data).borrow();
+    let data = ctx.accounts.buffer.try_borrow_data()?;
 
     if !data.is_empty() {
         // make sure that the asset is uninitialized

--- a/programs/asset/program/src/processor/mod.rs
+++ b/programs/asset/program/src/processor/mod.rs
@@ -18,15 +18,14 @@ mod write;
 
 use borsh::BorshDeserialize;
 use nifty_asset_types::state::{Discriminator, Standard, State};
+use nitrate::program::{system, AccountInfo};
 use solana_program::{
-    account_info::AccountInfo,
     entrypoint::{ProgramResult, MAX_PERMITTED_DATA_INCREASE},
     msg,
-    program::invoke,
     program_error::ProgramError,
     pubkey::Pubkey,
     rent::Rent,
-    system_instruction, system_program,
+    system_program,
     sysvar::Sysvar,
 };
 
@@ -35,18 +34,17 @@ use crate::{
     error::AssetError,
     instruction::{
         accounts::{
-            AllocateAccounts, ApproveAccounts, BurnAccounts, CloseAccounts, CreateAccounts,
-            GroupAccounts, HandoverAccounts, LockAccounts, RemoveAccounts, RevokeAccounts,
-            TransferAccounts, UngroupAccounts, UnlockAccounts, UnverifyAccounts, UpdateAccounts,
-            VerifyAccounts, WriteAccounts,
+            Allocate, Approve, Burn, Close, Create, Group, Handover, Lock, Remove, Revoke,
+            Transfer, Ungroup, Unlock, Unverify, Update, Verify, Write,
         },
         Instruction,
     },
 };
 
-pub fn process_instruction<'a>(
+#[inline(always)]
+pub fn process_instruction(
     program_id: &Pubkey,
-    accounts: &'a [AccountInfo<'a>],
+    accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {
     let instruction: Instruction = Instruction::try_from_slice(instruction_data)
@@ -69,71 +67,71 @@ pub fn process_instruction<'a>(
     match instruction {
         Instruction::Allocate(args) => {
             msg!("Instruction: Allocate");
-            allocate::process_allocate(program_id, AllocateAccounts::context(accounts)?, args)
+            allocate::process_allocate(program_id, Allocate::context(accounts)?, args)
         }
         Instruction::Approve(args) => {
             msg!("Instruction: Approve");
-            approve::process_approve(program_id, ApproveAccounts::context(accounts)?, args)
+            approve::process_approve(program_id, Approve::context(accounts)?, args)
         }
         Instruction::Burn => {
             msg!("Instruction: Burn");
-            burn::process_burn(program_id, BurnAccounts::context(accounts)?)
+            burn::process_burn(program_id, Burn::context(accounts)?)
         }
         Instruction::Close => {
             msg!("Instruction: Close");
-            close::process_close(program_id, CloseAccounts::context(accounts)?)
+            close::process_close(program_id, Close::context(accounts)?)
         }
         Instruction::Create(args) => {
             msg!("Instruction: Create");
-            create::process_create(program_id, CreateAccounts::context(accounts)?, args)
+            create::process_create(program_id, Create::context(accounts)?, args)
         }
         Instruction::Group => {
             msg!("Instruction: Group");
-            group::process_group(program_id, GroupAccounts::context(accounts)?)
+            group::process_group(program_id, Group::context(accounts)?)
         }
         Instruction::Handover => {
             msg!("Instruction: Handover");
-            handover::process_handover(program_id, HandoverAccounts::context(accounts)?)
+            handover::process_handover(program_id, Handover::context(accounts)?)
         }
         Instruction::Lock => {
             msg!("Instruction: Lock");
-            lock::process_lock(program_id, LockAccounts::context(accounts)?)
+            lock::process_lock(program_id, Lock::context(accounts)?)
         }
         Instruction::Remove(args) => {
             msg!("Instruction: Remove");
-            remove::process_remove(program_id, RemoveAccounts::context(accounts)?, args)
+            remove::process_remove(program_id, Remove::context(accounts)?, args)
         }
         Instruction::Revoke(args) => {
             msg!("Instruction: Revoke");
-            revoke::process_revoke(program_id, RevokeAccounts::context(accounts)?, args)
+            revoke::process_revoke(program_id, Revoke::context(accounts)?, args)
         }
         Instruction::Transfer => {
             msg!("Instruction: Transfer");
-            transfer::process_transfer(program_id, TransferAccounts::context(accounts)?)
+            transfer::process_transfer(program_id, Transfer::context(accounts)?)
         }
         Instruction::Ungroup => {
             msg!("Instruction: Ungroup");
-            ungroup::process_ungroup(program_id, UngroupAccounts::context(accounts)?)
+            ungroup::process_ungroup(program_id, Ungroup::context(accounts)?)
         }
         Instruction::Unlock => {
             msg!("Instruction: Unlock");
-            unlock::process_unlock(program_id, UnlockAccounts::context(accounts)?)
+            unlock::process_unlock(program_id, Unlock::context(accounts)?)
         }
         Instruction::Unverify => {
             msg!("Instruction: Unverify");
-            unverify::process_unverify(program_id, UnverifyAccounts::context(accounts)?)
+            unverify::process_unverify(program_id, Unverify::context(accounts)?)
         }
         Instruction::Update(args) => {
             msg!("Instruction: Update");
-            update::process_update(program_id, UpdateAccounts::context(accounts)?, args)
+            update::process_update(program_id, Update::context(accounts)?, args)
         }
         Instruction::Verify => {
             msg!("Instruction: Verify");
-            verify::process_verify(program_id, VerifyAccounts::context(accounts)?)
+            verify::process_verify(program_id, Verify::context(accounts)?)
         }
         Instruction::Write(args) => {
             msg!("Instruction: Write");
-            write::process_write(program_id, WriteAccounts::context(accounts)?, args)
+            write::process_write(program_id, Write::context(accounts)?, args)
         }
     }
 }
@@ -169,31 +167,31 @@ fn validate_access<'a>(
     // we only check the first account of each instruction for `Proxied` assets,
     // since this is the "active" asset on the instruction
     if let Some(account_info) = accounts.first() {
-        let data = account_info.data.borrow();
+        let data = account_info.try_borrow_data()?;
 
-        if account_info.owner == program_id
+        if account_info.owner() == program_id
             && !account_info.data_is_empty()
             && data[STANDARD_INDEX] == Standard::Proxied.into()
         {
             require!(
-                account_info.is_signer,
+                account_info.is_signer(),
                 ProgramError::MissingRequiredSignature,
                 "proxied asset \"{}\" is not a signer",
-                account_info.key
+                account_info.key()
             );
         }
     }
 
     for account_info in accounts {
         // only considers accounts owned by the program and non-empty
-        if account_info.owner == program_id && !account_info.data_is_empty() {
-            let data = account_info.data.borrow();
+        if account_info.owner() == program_id && !account_info.data_is_empty() {
+            let data = account_info.try_borrow_data()?;
             if data[DISCRIMINATOR_INDEX] == Discriminator::Asset.into()
                 && data[STATE_INDEX] == State::Locked.into()
             {
                 // any locked asset can be used to determine if the
                 // instruction is allowed
-                return Ok(Some(account_info.key));
+                return Ok(Some(account_info.key()));
             }
         }
     }
@@ -204,24 +202,25 @@ fn validate_access<'a>(
 #[inline(always)]
 fn resize<'a>(
     size: usize,
-    account: &'a AccountInfo<'a>,
-    payer: Option<&'a AccountInfo<'a>>,
-    system_program: Option<&'a AccountInfo<'a>>,
+    account: &'a AccountInfo,
+    payer: Option<&'a AccountInfo>,
+    system_program: Option<&'a AccountInfo>,
 ) -> ProgramResult {
     let required = Rent::get()?.minimum_balance(size);
 
     if account.data_len() > size {
-        let delta = account
-            .lamports()
-            .saturating_sub(if size == 0 { 0 } else { required });
+        let delta =
+            account
+                .try_borrow_lamports()?
+                .saturating_sub(if size == 0 { 0 } else { required });
 
         let payer = payer.ok_or_else(|| {
             msg!("[ERROR] Missing payer account");
             ProgramError::NotEnoughAccountKeys
         })?;
 
-        **payer.try_borrow_mut_lamports()? += delta;
-        **account.try_borrow_mut_lamports()? -= delta;
+        *payer.try_borrow_mut_lamports()? += delta;
+        *account.try_borrow_mut_lamports()? -= delta;
     } else {
         if size.saturating_sub(account.data_len()) > MAX_PERMITTED_DATA_INCREASE {
             return err!(
@@ -231,7 +230,7 @@ fn resize<'a>(
             );
         }
 
-        let delta = required.saturating_sub(account.lamports());
+        let delta = required.saturating_sub(*account.try_borrow_lamports()?);
 
         if delta > 0 {
             #[cfg(feature = "logging")]
@@ -248,21 +247,18 @@ fn resize<'a>(
             })?;
 
             crate::require!(
-                payer.is_signer,
+                payer.is_signer(),
                 ProgramError::MissingRequiredSignature,
                 "payer"
             );
 
             crate::require!(
-                system_program.key == &system_program::ID,
+                system_program.key() == &system_program::ID,
                 ProgramError::IncorrectProgramId,
                 "system_program"
             );
 
-            invoke(
-                &system_instruction::transfer(payer.key, account.key, delta),
-                &[account.clone(), payer.clone()],
-            )?;
+            system::transfer(payer, account, delta);
         }
     }
 

--- a/programs/asset/program/src/processor/ungroup.rs
+++ b/programs/asset/program/src/processor/ungroup.rs
@@ -8,7 +8,7 @@ use solana_program::{entrypoint::ProgramResult, program_error::ProgramError, pub
 use crate::{
     err,
     error::AssetError,
-    instruction::accounts::{Context, UngroupAccounts},
+    instruction::accounts::{Context, Ungroup},
     require,
 };
 
@@ -19,28 +19,28 @@ use crate::{
 ///   0. `[writable]` asset
 ///   1. `[writable]` group
 ///   2. `[signer]` authority
-pub fn process_ungroup(program_id: &Pubkey, ctx: Context<UngroupAccounts>) -> ProgramResult {
+pub fn process_ungroup(program_id: &Pubkey, ctx: Context<Ungroup>) -> ProgramResult {
     // account validation
 
     require!(
-        ctx.accounts.authority.is_signer,
+        ctx.accounts.authority.is_signer(),
         ProgramError::MissingRequiredSignature,
         "authority"
     );
 
     require!(
-        ctx.accounts.asset.owner == program_id,
+        ctx.accounts.asset.owner() == program_id,
         ProgramError::IllegalOwner,
         "asset"
     );
 
     require!(
-        ctx.accounts.group.owner == program_id,
+        ctx.accounts.group.owner() == program_id,
         ProgramError::IllegalOwner,
         "group"
     );
 
-    let mut asset_data = (*ctx.accounts.asset.data).borrow_mut();
+    let mut asset_data = ctx.accounts.asset.try_borrow_mut_data()?;
 
     require!(
         asset_data.len() >= Asset::LEN && asset_data[0] == Discriminator::Asset.into(),
@@ -48,7 +48,7 @@ pub fn process_ungroup(program_id: &Pubkey, ctx: Context<UngroupAccounts>) -> Pr
         "asset"
     );
 
-    let mut group_data = (*ctx.accounts.group.data).borrow_mut();
+    let mut group_data = ctx.accounts.group.try_borrow_mut_data()?;
 
     require!(
         group_data.len() >= Asset::LEN && group_data[0] == Discriminator::Asset.into(),
@@ -63,7 +63,7 @@ pub fn process_ungroup(program_id: &Pubkey, ctx: Context<UngroupAccounts>) -> Pr
 
     // asset must be in the group
     require!(
-        asset.group == PodOption::new(ctx.accounts.group.key.into()),
+        asset.group == PodOption::new(ctx.accounts.group.key().into()),
         ProgramError::InvalidArgument,
         "asset group mismatch"
     );
@@ -78,11 +78,11 @@ pub fn process_ungroup(program_id: &Pubkey, ctx: Context<UngroupAccounts>) -> Pr
     };
 
     // if the signing authority doesn't match the group authority
-    if *ctx.accounts.authority.key != group.authority {
+    if *ctx.accounts.authority.key() != group.authority {
         // then the authority must match the grouping delegate
         if let Some(delegate) = grouping.delegate.value() {
             require!(
-                **delegate == *ctx.accounts.authority.key,
+                **delegate == *ctx.accounts.authority.key(),
                 AssetError::InvalidAuthority,
                 "Group authority or delegate mismatch"
             );

--- a/programs/asset/program/src/processor/unlock.rs
+++ b/programs/asset/program/src/processor/unlock.rs
@@ -7,7 +7,7 @@ use solana_program::{entrypoint::ProgramResult, program_error::ProgramError, pub
 
 use crate::{
     error::AssetError,
-    instruction::accounts::{Context, UnlockAccounts},
+    instruction::accounts::{Context, Unlock},
     require,
     utils::assert_delegate,
 };
@@ -18,22 +18,22 @@ use crate::{
 ///
 ///   0. `[writable]` asset
 ///   1. `[signer]` signer
-pub fn process_unlock(program_id: &Pubkey, ctx: Context<UnlockAccounts>) -> ProgramResult {
+pub fn process_unlock(program_id: &Pubkey, ctx: Context<Unlock>) -> ProgramResult {
     // account validation
 
     require!(
-        ctx.accounts.signer.is_signer,
+        ctx.accounts.signer.is_signer(),
         ProgramError::MissingRequiredSignature,
         "signer"
     );
 
     require!(
-        ctx.accounts.asset.owner == program_id,
+        ctx.accounts.asset.owner() == program_id,
         ProgramError::IllegalOwner,
         "asset"
     );
 
-    let mut data = (*ctx.accounts.asset.data).borrow_mut();
+    let mut data = ctx.accounts.asset.try_borrow_mut_data()?;
 
     require!(
         data.len() >= Asset::LEN && data[0] == Discriminator::Asset.into(),
@@ -54,14 +54,14 @@ pub fn process_unlock(program_id: &Pubkey, ctx: Context<UnlockAccounts>) -> Prog
     if asset.delegate.value().is_some() {
         assert_delegate(
             &[asset.delegate.value(), manager],
-            ctx.accounts.signer.key,
+            ctx.accounts.signer.key(),
             DelegateRole::Lock,
         )?;
     }
     // otherwise, if the signer is not the owner, the signer must be the
     // manager delegate
-    else if asset.owner != *ctx.accounts.signer.key {
-        assert_delegate(&[manager], ctx.accounts.signer.key, DelegateRole::Lock)?;
+    else if asset.owner != *ctx.accounts.signer.key() {
+        assert_delegate(&[manager], ctx.accounts.signer.key(), DelegateRole::Lock)?;
     }
 
     asset.state = State::Unlocked;

--- a/programs/asset/program/src/processor/verify.rs
+++ b/programs/asset/program/src/processor/verify.rs
@@ -7,7 +7,7 @@ use solana_program::{entrypoint::ProgramResult, program_error::ProgramError, pub
 use crate::{
     err,
     error::AssetError,
-    instruction::accounts::{Context, VerifyAccounts},
+    instruction::accounts::{Context, Verify},
     require,
 };
 
@@ -17,22 +17,22 @@ use crate::{
 ///
 ///   0. `[writable]` asset
 ///   1. `[signer]` creator
-pub fn process_verify(program_id: &Pubkey, ctx: Context<VerifyAccounts>) -> ProgramResult {
+pub fn process_verify(program_id: &Pubkey, ctx: Context<Verify>) -> ProgramResult {
     // account validation
 
     require!(
-        ctx.accounts.creator.is_signer,
+        ctx.accounts.creator.is_signer(),
         ProgramError::MissingRequiredSignature,
         "missing creator signature"
     );
 
     require!(
-        ctx.accounts.asset.owner == program_id,
+        ctx.accounts.asset.owner() == program_id,
         ProgramError::IllegalOwner,
         "invalid asset account owner"
     );
 
-    let mut data = (*ctx.accounts.asset.data).borrow_mut();
+    let mut data = ctx.accounts.asset.try_borrow_mut_data()?;
 
     require!(
         data.len() >= Asset::LEN && data[0] == Discriminator::Asset.into(),
@@ -54,7 +54,7 @@ pub fn process_verify(program_id: &Pubkey, ctx: Context<VerifyAccounts>) -> Prog
     let mut found = false;
 
     extension.creators.iter_mut().for_each(|creator| {
-        if creator.address == *ctx.accounts.creator.key {
+        if creator.address == *ctx.accounts.creator.key() {
             creator.verified = true.into();
             found = true;
         }

--- a/programs/asset/program/src/utils.rs
+++ b/programs/asset/program/src/utils.rs
@@ -1,25 +1,27 @@
-use nifty_asset_types::state::{Delegate, DelegateRole};
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey, system_program,
+use nifty_asset_types::{
+    constraints::Target,
+    state::{Delegate, DelegateRole},
 };
+use nitrate::program::AccountInfo;
+use solana_program::{entrypoint::ProgramResult, pubkey::Pubkey, system_program};
 
 use crate::{error::AssetError, require};
 
-pub fn close_program_account<'a>(
-    account_info: &AccountInfo<'a>,
-    funds_dest_account_info: &AccountInfo<'a>,
-) -> ProgramResult {
-    // Transfer lamports from the account to the destination account.
-    let dest_starting_lamports = funds_dest_account_info.lamports();
-    **funds_dest_account_info.lamports.borrow_mut() = dest_starting_lamports
-        .checked_add(account_info.lamports())
-        .unwrap();
-    **account_info.lamports.borrow_mut() = 0;
+#[inline(always)]
+pub fn close_program_account(account: &AccountInfo, recipient: &AccountInfo) -> ProgramResult {
+    // transfer lamports from the account to the destination account.
+    let mut destination_lamports = recipient.try_borrow_mut_lamports()?;
+    let mut source_lamports = account.try_borrow_mut_lamports()?;
 
-    // Realloc the account data size to 0 bytes and re-assign ownership of
+    *destination_lamports = (*destination_lamports)
+        .checked_add(*source_lamports)
+        .unwrap();
+    *source_lamports = 0;
+
+    // realloc the account data size to 0 bytes and re-assign ownership of
     // the account to the system program
-    account_info.realloc(0, false)?;
-    account_info.assign(&system_program::ID);
+    account.realloc(0, false)?;
+    account.assign(&system_program::ID);
 
     Ok(())
 }
@@ -58,45 +60,66 @@ pub fn assert_delegate(
 
 #[macro_export]
 macro_rules! process_royalties {
-    ( $ctx:expr, $data:expr) => {
-        {
-            // Check if royalties extension is present.
-            if let Some(royalties) = Asset::get::<Royalties>($data) {
-                // Check if the recipient is allowed to receive the asset.
+    ( $ctx:expr, $data:expr) => {{
+        // Check if royalties extension is present.
+        if let Some(royalties) = Asset::get::<Royalties>($data) {
+            // Check if the recipient is allowed to receive the asset.
 
-                // Wallet-to-wallet transfers between system program accounts are exempt from the royalty check
-                // so we need to exclude them.
+            // Wallet-to-wallet transfers between system program accounts are exempt from the
+            // royalty check so we need to exclude them.
+            //
+            // To determine if the transaction is a wallet-to-wallet transfer, we check:
+            //
+            //   1. Are we in a CPI? If so, the signer could be a ghost PDA so we
+            //      cannot prove it's a wallet.
+            //
+            //   2. Are both the sender and the recipient system program accounts?
+            let is_wallet_to_wallet = !(get_stack_height() > TRANSACTION_LEVEL_STACK_HEIGHT)
+                && ($ctx.accounts.signer.owner() == &solana_program::system_program::ID)
+                && ($ctx.accounts.recipient.owner() == &solana_program::system_program::ID);
 
-                // Are we in a CPI? If so, the signer could be a ghost PDA so we cannot prove it's a wallet.
-                let is_cpi = get_stack_height() > TRANSACTION_LEVEL_STACK_HEIGHT;
+            if !is_wallet_to_wallet {
+                #[cfg(feature = "logging")]
+                solana_program::msg!("Checking royalties constraint");
 
-                // Are both the sender and the recipient system program accounts?
-                let sender_is_wallet =
-                    $ctx.accounts.signer.owner == &solana_program::system_program::id();
-                let recipient_is_wallet =
-                    $ctx.accounts.recipient.owner == &solana_program::system_program::id();
+                // We pass in the `ConstraintContext` and validate the royalties constraint.
+                let result = royalties.constraint.assertable.assert(&ConstraintContext {
+                    asset: &$crate::utils::Account($ctx.accounts.asset),
+                    authority: &$crate::utils::Account($ctx.accounts.signer),
+                    recipient: Some(&$crate::utils::Account($ctx.accounts.recipient)),
+                })?;
 
-                let is_wallet_to_wallet = !is_cpi && sender_is_wallet && recipient_is_wallet;
-
-                if !is_wallet_to_wallet {
-                    msg!("Checking royalties constraint");
-                    // We pass in the Constraint context and validate the royalties constraint.
-                    let result = royalties.constraint.assertable.assert(&ConstraintContext {
-                        asset: $ctx.accounts.asset,
-                        authority: $ctx.accounts.signer,
-                        recipient: Some($ctx.accounts.recipient),
-                    })?;
-                    require!(
-                        result == Assertion::Pass,
-                        AssetError::AssertionFailure,
-                        "constraint failed"
-                    );
-                }
-
-                true // royalties checked
-            } else {
-                false // no royalties extension
+                require!(
+                    result == Assertion::Pass,
+                    AssetError::AssertionFailure,
+                    "constraint failed"
+                );
             }
+
+            // royalties checked
+            true
+        } else {
+            // no royalties extension
+            false
         }
+    }};
+}
+
+pub struct Account<'a>(pub &'a AccountInfo);
+
+impl Target for Account<'_> {
+    #[inline(always)]
+    fn is_empty(&self) -> bool {
+        self.0.data_is_empty()
+    }
+
+    #[inline(always)]
+    fn key(&self) -> &Pubkey {
+        self.0.key()
+    }
+
+    #[inline(always)]
+    fn owner(&self) -> &Pubkey {
+        self.0.owner()
     }
 }

--- a/programs/asset/types/src/constraints/mod.rs
+++ b/programs/asset/types/src/constraints/mod.rs
@@ -14,22 +14,39 @@ pub use pubkey_match::*;
 
 use bytemuck::{Pod, Zeroable};
 use podded::ZeroCopy;
-use solana_program::{account_info::AccountInfo, program_error::ProgramError};
+use solana_program::{program_error::ProgramError, pubkey::Pubkey};
 use std::fmt::{self, Debug};
 
 /// The result of a constraint evaluation.
 pub type AssertionResult = Result<Assertion, ProgramError>;
 
 /// The context of a constraint evaluation.
-pub struct Context<'a, 'b> {
+pub struct Context<'a> {
     /// The asset participating in the action.
-    pub asset: &'b AccountInfo<'a>,
+    pub asset: &'a dyn Target,
 
     /// The account authorizing the action.
-    pub authority: &'b AccountInfo<'a>,
+    pub authority: &'a dyn Target,
 
     /// The recipient account when the action is a transfer.
-    pub recipient: Option<&'b AccountInfo<'a>>,
+    pub recipient: Option<&'a dyn Target>,
+}
+
+/// Defines the target of a constraint.
+///
+/// A target is a data structure that has a key and an owner. In most cases
+/// this will be an `AccountInfo` struct.
+pub trait Target {
+    /// The key of the target.
+    fn key(&self) -> &Pubkey;
+
+    /// The owner of the target.
+    fn owner(&self) -> &Pubkey;
+
+    /// Indicates whether the target's data is empty.
+    ///
+    /// Note that even when the data is not empty, it can still be zeroed out.
+    fn is_empty(&self) -> bool;
 }
 
 #[repr(u64)]

--- a/programs/asset/types/src/constraints/owned_by.rs
+++ b/programs/asset/types/src/constraints/owned_by.rs
@@ -33,7 +33,7 @@ impl Assertable for OwnedBy<'_> {
         let account = get_account!(self.account, context);
 
         Ok(
-            if self.owners.contains(account.owner) && !account.data_is_empty() {
+            if self.owners.contains(account.owner()) && !account.is_empty() {
                 Assertion::Pass
             } else {
                 Assertion::Failure

--- a/programs/asset/types/src/constraints/pubkey_match.rs
+++ b/programs/asset/types/src/constraints/pubkey_match.rs
@@ -32,7 +32,7 @@ impl Assertable for PubkeyMatch<'_> {
     fn assert(&self, context: &Context) -> AssertionResult {
         let account = get_account!(self.account, context);
 
-        Ok(if self.pubkeys.contains(account.key) {
+        Ok(if self.pubkeys.contains(account.key()) {
             Assertion::Pass
         } else {
             Assertion::Failure


### PR DESCRIPTION
This PR switches the program entrypoint to use [`nitrate`](https://github.com/nifty-oss/nitrate), lowering the compute units consumption since the entrypoint does not need to allocate or copy data from the input buffer.