### PR TITLE
Remove account length constraint

### DIFF
--- a/clients/js/asset/src/updateWithBuffer.ts
+++ b/clients/js/asset/src/updateWithBuffer.ts
@@ -1,10 +1,11 @@
 import {
   Context,
+  PublicKey,
   TransactionBuilderGroup,
   generateSigner,
   transactionBuilderGroup,
 } from '@metaplex-foundation/umi';
-import { SYSTEM_PROGRAM_ID } from '.';
+import { ASSET_PROGRAM_ID, SYSTEM_PROGRAM_ID, close } from '.';
 import { TypedExtension, getExtensionSerializerFromType } from './extensions';
 import {
   UpdateInstructionAccounts,
@@ -23,15 +24,40 @@ export function updateWithBuffer(
     Omit<UpdateInstructionArgs, 'extension'> & {
       extension: TypedExtension;
       chunkSize?: number;
-    }
+    } & { proxy?: PublicKey }
 ): TransactionBuilderGroup {
   const data = getExtensionSerializerFromType(input.extension.type).serialize(
     input.extension
   );
   const chunked = data.length > (input.chunkSize ?? DEFAULT_CHUNK_SIZE);
 
+  if (input.proxy) {
+    const proxied = context.programs.clone();
+    proxied.bind('asset', input.proxy);
+    context = { ...context, programs: proxied };
+  }
+
   if (chunked) {
     const buffer = generateSigner(context);
+
+    let updateIx = update(context, {
+      ...input,
+      buffer: buffer.publicKey,
+      systemProgram: SYSTEM_PROGRAM_ID,
+      extension: {
+        extensionType: input.extension.type,
+        length: data.length,
+        data: null,
+      },
+    });
+
+    if (input.proxy) {
+      updateIx = updateIx.addRemainingAccounts({
+        pubkey: ASSET_PROGRAM_ID,
+        isWritable: false,
+        isSigner: false,
+      });
+    }
 
     return write(context, {
       ...input,
@@ -49,28 +75,31 @@ export function updateWithBuffer(
           },
         })
       )
+      .append(updateIx)
       .append(
-        update(context, {
-          ...input,
-          buffer: buffer.publicKey,
-          systemProgram: SYSTEM_PROGRAM_ID,
-          extension: {
-            extensionType: input.extension.type,
-            length: data.length,
-            data: chunked ? null : data,
-          },
+        close(context, {
+          buffer,
+          recipient: input.payer?.publicKey ?? context.payer.publicKey,
         })
       );
   }
 
-  return transactionBuilderGroup([
-    update(context, {
-      ...input,
-      extension: {
-        extensionType: input.extension.type,
-        length: data.length,
-        data,
-      },
-    }),
-  ]);
+  let updateIx = update(context, {
+    ...input,
+    extension: {
+      extensionType: input.extension.type,
+      length: data.length,
+      data,
+    },
+  });
+
+  if (input.proxy) {
+    updateIx = updateIx.addRemainingAccounts({
+      pubkey: ASSET_PROGRAM_ID,
+      isWritable: false,
+      isSigner: false,
+    });
+  }
+
+  return transactionBuilderGroup([updateIx]);
 }

--- a/clients/js/asset/src/updateWithBuffer.ts
+++ b/clients/js/asset/src/updateWithBuffer.ts
@@ -3,17 +3,18 @@ import {
   PublicKey,
   TransactionBuilderGroup,
   generateSigner,
+  none,
   transactionBuilderGroup,
 } from '@metaplex-foundation/umi';
 import { ASSET_PROGRAM_ID, SYSTEM_PROGRAM_ID, close } from '.';
 import { TypedExtension, getExtensionSerializerFromType } from './extensions';
+import { allocate } from './generated/instructions/allocate';
 import {
   UpdateInstructionAccounts,
   UpdateInstructionArgs,
   update,
 } from './generated/instructions/update';
 import { DEFAULT_CHUNK_SIZE, write } from './write';
-import { allocate } from './generated/instructions/allocate';
 
 export function updateWithBuffer(
   context: Pick<
@@ -44,11 +45,7 @@ export function updateWithBuffer(
       ...input,
       buffer: buffer.publicKey,
       systemProgram: SYSTEM_PROGRAM_ID,
-      extension: {
-        extensionType: input.extension.type,
-        length: data.length,
-        data: null,
-      },
+      extension: none(),
     });
 
     if (input.proxy) {

--- a/programs/asset/program/src/processor/update.rs
+++ b/programs/asset/program/src/processor/update.rs
@@ -111,7 +111,13 @@ pub fn process_update(
     // the update was successful
     if args.extension.is_some() || ctx.accounts.buffer.is_some() {
         // extension data can be specified through a buffer account or
-        // instruction args (buffer account takes precedence over args)
+        // instruction args, but not both
+        require!(
+            args.extension.is_some() != ctx.accounts.buffer.is_some(),
+            ProgramError::InvalidInstructionData,
+            "only specify instruction args or buffer account"
+        );
+
         let extension_type = if let Some(buffer) = ctx.accounts.buffer {
             require!(
                 buffer.owner() == program_id,

--- a/programs/asset/program/src/processor/update.rs
+++ b/programs/asset/program/src/processor/update.rs
@@ -253,11 +253,6 @@ pub fn process_update(
         let delta = updated_boundary as i32 - boundary as i32;
 
         if !update {
-            require!(
-                offset == account_data.len(),
-                ProgramError::InvalidAccountData,
-                "extension offset mismatch"
-            );
             // drop the borrow to resize the account
             drop(account_data);
 

--- a/programs/asset/program/src/processor/update.rs
+++ b/programs/asset/program/src/processor/update.rs
@@ -111,10 +111,8 @@ pub fn process_update(
     // the update was successful
     if args.extension.is_some() || ctx.accounts.buffer.is_some() {
         // extension data can be specified through a buffer account or
-        // instruction args
-        let extension_type = if let Some(args) = &args.extension {
-            args.extension_type
-        } else if let Some(buffer) = ctx.accounts.buffer {
+        // instruction args (buffer account takes precedence over args)
+        let extension_type = if let Some(buffer) = ctx.accounts.buffer {
             require!(
                 buffer.owner() == program_id,
                 ProgramError::IllegalOwner,
@@ -139,6 +137,8 @@ pub fn process_update(
                 Asset::first_extension(&extension_data).ok_or(AssetError::ExtensionNotFound)?;
 
             header.extension_type()
+        } else if let Some(args) = &args.extension {
+            args.extension_type
         } else {
             // sanity check: this should not happen since we already checked that we either
             // have extension args or a buffer account


### PR DESCRIPTION
This PR removes the requirement that the account must not contain any padding when adding a new extension.

This is currently preventing adding new extensions that require adding padding via the `resize` instruction since their data is greater than `MAX_PERMITTED_DATA_INCREASE`.