### PR TITLE
Add image uri field

### DIFF
--- a/clients/js/asset/src/extensions/metadata.ts
+++ b/clients/js/asset/src/extensions/metadata.ts
@@ -2,10 +2,11 @@ import { TypedExtension } from '.';
 import { ExtensionType, Metadata } from '../generated';
 
 export const metadata = (
-  input?: Partial<Pick<Metadata, 'symbol' | 'description' | 'uri'>>
+  input?: Partial<Pick<Metadata, 'symbol' | 'description' | 'uri' | 'imageUri'>>
 ): TypedExtension => ({
   type: ExtensionType.Metadata,
   symbol: input?.symbol ?? '',
   description: input?.description ?? '',
   uri: input?.uri ?? '',
+  imageUri: input?.imageUri ?? '',
 });

--- a/clients/js/asset/src/generated/types/metadata.ts
+++ b/clients/js/asset/src/generated/types/metadata.ts
@@ -13,7 +13,12 @@ import {
   u8,
 } from '@metaplex-foundation/umi/serializers';
 
-export type Metadata = { symbol: string; description: string; uri: string };
+export type Metadata = {
+  symbol: string;
+  description: string;
+  uri: string;
+  imageUri: string;
+};
 
 export type MetadataArgs = Metadata;
 
@@ -23,6 +28,7 @@ export function getMetadataSerializer(): Serializer<MetadataArgs, Metadata> {
       ['symbol', string({ size: u8() })],
       ['description', string({ size: u8() })],
       ['uri', string({ size: u8() })],
+      ['imageUri', string({ size: u8() })],
     ],
     { description: 'Metadata' }
   ) as Serializer<MetadataArgs, Metadata>;

--- a/clients/js/asset/src/hooked/assetAccountData.ts
+++ b/clients/js/asset/src/hooked/assetAccountData.ts
@@ -60,8 +60,15 @@ export const getAssetAccountDataSerializer = (): Serializer<
       if (type === ExtensionType.None) {
         break;
       } else if (ExtensionType[type]) {
+        let endOffset = headerOffset + header.length;
+        if (type === ExtensionType.Metadata) {
+          // backwards compatibility for metadata extension: there is now an 'imageUrl'
+          // on the extension, so we use the extra padding to simulate having it for
+          // assets created before the change.
+          endOffset = header.boundary;
+        }
         const [extension] = getExtensionSerializerFromType(type).deserialize(
-          buffer.subarray(headerOffset, headerOffset + header.length)
+          buffer.subarray(headerOffset, endOffset)
         );
         extensions.push({ ...extension, type } as TypedExtension);
       }

--- a/clients/js/asset/test/extensions/metadata.test.ts
+++ b/clients/js/asset/test/extensions/metadata.test.ts
@@ -27,6 +27,8 @@ test('it can create a new asset with a metadata', async (t) => {
       symbol: 'SMB',
       description: 'A metadata extension',
       uri: 'https://arweave.net/62Z5yOFbIeFqvoOl-aq75EAGSDzS-GxpIKC2ws5LVDc',
+      imageUri:
+        'https://arweave.net/Va823FYwx0jqbbtpGjJryJCr2FtJwfRTM1f8nNn3dyg',
     }),
   }).sendAndConfirm(umi);
 
@@ -53,6 +55,8 @@ test('it can create a new asset with a metadata', async (t) => {
         symbol: 'SMB',
         description: 'A metadata extension',
         uri: 'https://arweave.net/62Z5yOFbIeFqvoOl-aq75EAGSDzS-GxpIKC2ws5LVDc',
+        imageUri:
+          'https://arweave.net/Va823FYwx0jqbbtpGjJryJCr2FtJwfRTM1f8nNn3dyg',
       },
     ],
   });

--- a/clients/rust/asset/src/generated/types/metadata.rs
+++ b/clients/rust/asset/src/generated/types/metadata.rs
@@ -15,4 +15,5 @@ pub struct Metadata {
     pub symbol: U8PrefixString,
     pub description: U8PrefixString,
     pub uri: U8PrefixString,
+    pub image_uri: U8PrefixString,
 }

--- a/clients/rust/asset/tests/properties/mod.rs
+++ b/clients/rust/asset/tests/properties/mod.rs
@@ -99,7 +99,7 @@ async fn create_with_multiple() {
     // And multiple extensions.
 
     let mut metadata = MetadataBuilder::default();
-    metadata.set(Some("NIFTY"), None, None);
+    metadata.set(Some("NIFTY"), None, None, None);
 
     let mut properties = PropertiesBuilder::default();
     properties.add_text("name", "nifty");

--- a/configs/kinobi-asset.cjs
+++ b/configs/kinobi-asset.cjs
@@ -305,6 +305,12 @@ kinobi.update(
                     size: k.prefixedSizeNode(k.numberTypeNode("u8")),
                   }),
                 }),
+                k.structFieldTypeNode({
+                  name: "imageUri",
+                  type: k.stringTypeNode({
+                    size: k.prefixedSizeNode(k.numberTypeNode("u8")),
+                  }),
+                }),
               ]),
             }),
             // grouping

--- a/programs/asset/types/src/extensions/metadata.rs
+++ b/programs/asset/types/src/extensions/metadata.rs
@@ -3,17 +3,25 @@ use std::{fmt::Debug, ops::Deref};
 
 use super::{ExtensionBuilder, ExtensionData, ExtensionDataMut, ExtensionType, Lifecycle};
 
-/// Extension to add `symbol`, `description` and `uri` values to an asset.
+/// Empty string used for backwards compatibility with metadata extension.
+const ZERO_STR: [u8; 1] = [0u8];
+
+/// Extension to add metadata values to an asset.
 ///
-/// This extension is used to add Token Metadata's commonly used `symbol`, `description` and `uri`
-/// values to an asset.
+/// This extension is used to add Token Metadata's commonly used `symbol`, `description`, `uri`
+/// and `image_uri` values to an asset.
 pub struct Metadata<'a> {
     /// Symbol for the asset.
     pub symbol: U8PrefixStr<'a>,
+
     /// Description of the asset.
     pub description: U8PrefixStr<'a>,
+
     /// "Pointer" URI for external metadata.
     pub uri: U8PrefixStr<'a>,
+
+    /// "Pointer" URI for external image.
+    pub image_uri: U8PrefixStr<'a>,
 }
 
 impl<'a> ExtensionData<'a> for Metadata<'a> {
@@ -21,18 +29,32 @@ impl<'a> ExtensionData<'a> for Metadata<'a> {
 
     fn from_bytes(bytes: &'a [u8]) -> Self {
         let symbol = U8PrefixStr::from_bytes(bytes);
-        let description = U8PrefixStr::from_bytes(&bytes[symbol.size()..]);
-        let uri = U8PrefixStr::from_bytes(&bytes[symbol.size() + description.size()..]);
+        let mut offset = symbol.size();
+
+        let description = U8PrefixStr::from_bytes(&bytes[offset..]);
+        offset += description.size();
+
+        let uri = U8PrefixStr::from_bytes(&bytes[offset..]);
+        offset += uri.size();
+
+        let image_uri = if offset >= bytes.len() {
+            // backwards compatibility for metadata extension: if there are not enough
+            // bytes to read the image_uri, we assume it is empty
+            U8PrefixStr::from_bytes(&ZERO_STR)
+        } else {
+            U8PrefixStr::from_bytes(&bytes[offset..])
+        };
 
         Self {
             symbol,
             description,
             uri,
+            image_uri,
         }
     }
 
     fn length(&self) -> usize {
-        self.symbol.size() + self.description.size() + self.uri.size()
+        self.symbol.size() + self.description.size() + self.uri.size() + self.image_uri.size()
     }
 }
 
@@ -42,6 +64,7 @@ impl Debug for Metadata<'_> {
             .field("symbol", &self.symbol.as_str())
             .field("description", &self.description.as_str())
             .field("uri", &self.uri.as_str())
+            .field("image_uri", &self.image_uri.as_str())
             .finish()
     }
 }
@@ -53,10 +76,15 @@ impl Debug for Metadata<'_> {
 pub struct MetadataMut<'a> {
     /// Symbol for the asset.
     pub symbol: U8PrefixStrMut<'a>,
+
     /// Description of the asset.
     pub description: U8PrefixStrMut<'a>,
+
     /// "Pointer" URI for external metadata.
     pub uri: U8PrefixStrMut<'a>,
+
+    /// "Pointer" URI for external image.
+    pub image_uri: U8PrefixStrMut<'a>,
 }
 
 impl<'a> ExtensionDataMut<'a> for MetadataMut<'a> {
@@ -67,29 +95,45 @@ impl<'a> ExtensionDataMut<'a> for MetadataMut<'a> {
         // the bytes into mutable references
 
         let symbol = U8PrefixStr::from_bytes(bytes);
-        let symbol_size = symbol.size();
+        let mut offset = symbol.size();
 
-        let description = U8PrefixStr::from_bytes(&bytes[symbol_size..]);
-        let description_size = description.size();
-
-        let (symbol, remaining) = bytes.split_at_mut(symbol_size);
+        let (symbol, remaining) = bytes.split_at_mut(offset);
         let symbol = U8PrefixStrMut::from_bytes_mut(symbol);
 
-        let (description, uri) = remaining.split_at_mut(description_size);
+        let description = U8PrefixStr::from_bytes(remaining);
+        offset = description.size();
+
+        let (description, remaining) = remaining.split_at_mut(offset);
         let description = U8PrefixStrMut::from_bytes_mut(description);
+
+        let uri = U8PrefixStr::from_bytes(remaining);
+        offset = uri.size();
+
+        let (uri, image_uri) = remaining.split_at_mut(offset);
         let uri = U8PrefixStrMut::from_bytes_mut(uri);
+
+        let image_uri = if image_uri.is_empty() {
+            // backwards compatibility for metadata extension: if there are not enough
+            // bytes to read the image_uri, we assume it is empty
+            U8PrefixStrMut::from_bytes_mut(unsafe {
+                (&ZERO_STR as *const [u8] as *mut [u8]).as_mut().unwrap()
+            })
+        } else {
+            U8PrefixStrMut::from_bytes_mut(image_uri)
+        };
 
         Self {
             symbol,
             description,
             uri,
+            image_uri,
         }
     }
 }
 
 impl Lifecycle for MetadataMut<'_> {}
 
-/// Builder for an `Attributes` extension.
+/// Builder for a `Metadata` extension.
 #[derive(Default)]
 pub struct MetadataBuilder(Vec<u8>);
 
@@ -102,12 +146,13 @@ impl MetadataBuilder {
         Self(buffer)
     }
 
-    /// Add a new attribute to the extension.
+    /// Set the metadata values.
     pub fn set(
         &mut self,
         symbol: Option<&str>,
         description: Option<&str>,
         uri: Option<&str>,
+        image_uri: Option<&str>,
     ) -> &mut Self {
         // setting the data replaces any existing data
         self.0.clear();
@@ -145,6 +190,17 @@ impl MetadataBuilder {
             self.0.append(&mut vec![0u8; 1]);
         }
 
+        // add the length of the image_uri + prefix to the data buffer.
+        let cursor = self.0.len();
+
+        if let Some(image_uri) = image_uri {
+            self.0.append(&mut vec![0u8; image_uri.len() + 1]);
+            let mut uri_str = U8PrefixStrMut::new(&mut self.0[cursor..]);
+            uri_str.copy_from_str(image_uri);
+        } else {
+            self.0.append(&mut vec![0u8; 1]);
+        }
+
         self
     }
 }
@@ -169,7 +225,9 @@ impl Deref for MetadataBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::extensions::{ExtensionData, Metadata, MetadataBuilder};
+    use crate::extensions::{
+        ExtensionBuilder, ExtensionData, ExtensionDataMut, Metadata, MetadataBuilder, MetadataMut,
+    };
 
     #[test]
     fn test_set() {
@@ -178,6 +236,7 @@ mod tests {
             Some("SMB"),
             None,
             Some("https://arweave.net/62Z5yOFbIeFqvoOl-aq75EAGSDzS-GxpIKC2ws5LVDc"),
+            None,
         );
         let metadata = Metadata::from_bytes(&builder);
 
@@ -186,5 +245,42 @@ mod tests {
             metadata.uri.as_str(),
             "https://arweave.net/62Z5yOFbIeFqvoOl-aq75EAGSDzS-GxpIKC2ws5LVDc"
         );
+    }
+
+    #[test]
+    fn test_set_image_uri() {
+        let mut builder = MetadataBuilder::default();
+        builder.set(
+            Some("SMB"),
+            None,
+            None,
+            Some("https://arweave.net/62Z5yOFbIeFqvoOl-aq75EAGSDzS-GxpIKC2ws5LVDc"),
+        );
+        let metadata = Metadata::from_bytes(&builder);
+
+        assert_eq!(metadata.symbol.as_str(), "SMB");
+        assert_eq!(
+            metadata.image_uri.as_str(),
+            "https://arweave.net/62Z5yOFbIeFqvoOl-aq75EAGSDzS-GxpIKC2ws5LVDc"
+        );
+    }
+
+    #[test]
+    fn test_compatibility() {
+        let mut builder = MetadataBuilder::default();
+        builder.set(Some("SMB"), None, None, None);
+        let mut data = builder.data();
+        let length = data.len() - 1;
+
+        // remove the last byte to simulate the old metadata extension
+        let metadata = Metadata::from_bytes(&data[..length]);
+
+        assert_eq!(metadata.symbol.as_str(), "SMB");
+        assert_eq!(metadata.image_uri.as_str(), "");
+
+        let metadata = MetadataMut::from_bytes_mut(&mut data[..length]);
+
+        assert_eq!(metadata.symbol.as_str(), "SMB");
+        assert_eq!(metadata.image_uri.as_str(), "");
     }
 }

--- a/programs/bridge/src/processor/create.rs
+++ b/programs/bridge/src/processor/create.rs
@@ -198,7 +198,7 @@ pub fn process_create(
     ];
 
     let mut extension = MetadataBuilder::default();
-    extension.set(Some(&metadata.symbol), None, Some(&metadata.uri));
+    extension.set(Some(&metadata.symbol), None, Some(&metadata.uri), None);
     let data = extension.data();
 
     AllocateCpiBuilder::new(ctx.accounts.nifty_asset_program)


### PR DESCRIPTION
This PR adds the `image_uri` field to the metadata extension. This was done in a backwards-compatible way since the extension has padding to maintain the alignment.

cc: @joefitter @nilpferdschaefer @amilz 