### PR TITLE
Improve properties builder

### DIFF
--- a/clients/js/asset/src/generated/instructions/close.ts
+++ b/clients/js/asset/src/generated/instructions/close.ts
@@ -28,7 +28,7 @@ import {
 
 // Accounts.
 export type CloseInstructionAccounts = {
-  /** The unitialized buffer account */
+  /** The uninitialized buffer account */
   buffer: Signer;
   /** The account receiving refunded rent */
   recipient: PublicKey | Pda;

--- a/clients/js/asset/src/generated/instructions/create.ts
+++ b/clients/js/asset/src/generated/instructions/create.ts
@@ -51,7 +51,7 @@ export type CreateInstructionAccounts = {
   owner?: PublicKey | Pda;
   /** Asset account of the group */
   group?: PublicKey | Pda;
-  /** Optional authority for minting assets into a group */
+  /** Group authority for creating an asset into a group */
   groupAuthority?: Signer;
   /** The account paying for the storage fees */
   payer?: Signer;

--- a/clients/js/asset/src/generated/instructions/revoke.ts
+++ b/clients/js/asset/src/generated/instructions/revoke.ts
@@ -35,7 +35,7 @@ import {
 export type RevokeInstructionAccounts = {
   /** Asset account */
   asset: PublicKey | Pda;
-  /** Current owner of the asset or delegate */
+  /** Owner of the asset or current delegate */
   signer?: Signer;
 };
 

--- a/clients/js/asset/src/generated/instructions/update.ts
+++ b/clients/js/asset/src/generated/instructions/update.ts
@@ -43,7 +43,7 @@ export type UpdateInstructionAccounts = {
   asset: PublicKey | Pda;
   /** The authority of the asset */
   authority?: Signer;
-  /** Extension (asset) buffer account */
+  /** Extension buffer (uninitialized asset) account */
   buffer?: PublicKey | Pda;
   /** The asset defining the group, if applicable */
   group?: PublicKey | Pda;

--- a/clients/rust/asset/src/generated/instructions/close.rs
+++ b/clients/rust/asset/src/generated/instructions/close.rs
@@ -10,7 +10,7 @@ use borsh::BorshSerialize;
 
 /// Accounts.
 pub struct Close {
-    /// The unitialized buffer account
+    /// The uninitialized buffer account
     pub buffer: solana_program::pubkey::Pubkey,
     /// The account receiving refunded rent
     pub recipient: solana_program::pubkey::Pubkey,
@@ -73,7 +73,7 @@ impl CloseBuilder {
     pub fn new() -> Self {
         Self::default()
     }
-    /// The unitialized buffer account
+    /// The uninitialized buffer account
     #[inline(always)]
     pub fn buffer(&mut self, buffer: solana_program::pubkey::Pubkey) -> &mut Self {
         self.buffer = Some(buffer);
@@ -116,7 +116,7 @@ impl CloseBuilder {
 
 /// `close` CPI accounts.
 pub struct CloseCpiAccounts<'a, 'b> {
-    /// The unitialized buffer account
+    /// The uninitialized buffer account
     pub buffer: &'b solana_program::account_info::AccountInfo<'a>,
     /// The account receiving refunded rent
     pub recipient: &'b solana_program::account_info::AccountInfo<'a>,
@@ -126,7 +126,7 @@ pub struct CloseCpiAccounts<'a, 'b> {
 pub struct CloseCpi<'a, 'b> {
     /// The program to invoke.
     pub __program: &'b solana_program::account_info::AccountInfo<'a>,
-    /// The unitialized buffer account
+    /// The uninitialized buffer account
     pub buffer: &'b solana_program::account_info::AccountInfo<'a>,
     /// The account receiving refunded rent
     pub recipient: &'b solana_program::account_info::AccountInfo<'a>,
@@ -235,7 +235,7 @@ impl<'a, 'b> CloseCpiBuilder<'a, 'b> {
         });
         Self { instruction }
     }
-    /// The unitialized buffer account
+    /// The uninitialized buffer account
     #[inline(always)]
     pub fn buffer(
         &mut self,

--- a/clients/rust/asset/src/generated/instructions/create.rs
+++ b/clients/rust/asset/src/generated/instructions/create.rs
@@ -20,7 +20,7 @@ pub struct Create {
     pub owner: solana_program::pubkey::Pubkey,
     /// Asset account of the group
     pub group: Option<solana_program::pubkey::Pubkey>,
-    /// Optional authority for minting assets into a group
+    /// Group authority for creating an asset into a group
     pub group_authority: Option<solana_program::pubkey::Pubkey>,
     /// The account paying for the storage fees
     pub payer: Option<solana_program::pubkey::Pubkey>,
@@ -184,7 +184,7 @@ impl CreateBuilder {
         self
     }
     /// `[optional account]`
-    /// Optional authority for minting assets into a group
+    /// Group authority for creating an asset into a group
     #[inline(always)]
     pub fn group_authority(
         &mut self,
@@ -283,7 +283,7 @@ pub struct CreateCpiAccounts<'a, 'b> {
     pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Asset account of the group
     pub group: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    /// Optional authority for minting assets into a group
+    /// Group authority for creating an asset into a group
     pub group_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The account paying for the storage fees
     pub payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
@@ -303,7 +303,7 @@ pub struct CreateCpi<'a, 'b> {
     pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Asset account of the group
     pub group: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    /// Optional authority for minting assets into a group
+    /// Group authority for creating an asset into a group
     pub group_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The account paying for the storage fees
     pub payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
@@ -531,7 +531,7 @@ impl<'a, 'b> CreateCpiBuilder<'a, 'b> {
         self
     }
     /// `[optional account]`
-    /// Optional authority for minting assets into a group
+    /// Group authority for creating an asset into a group
     #[inline(always)]
     pub fn group_authority(
         &mut self,

--- a/clients/rust/asset/src/generated/instructions/revoke.rs
+++ b/clients/rust/asset/src/generated/instructions/revoke.rs
@@ -13,7 +13,7 @@ use borsh::BorshSerialize;
 pub struct Revoke {
     /// Asset account
     pub asset: solana_program::pubkey::Pubkey,
-    /// Current owner of the asset or delegate
+    /// Owner of the asset or current delegate
     pub signer: solana_program::pubkey::Pubkey,
 }
 
@@ -92,7 +92,7 @@ impl RevokeBuilder {
         self.asset = Some(asset);
         self
     }
-    /// Current owner of the asset or delegate
+    /// Owner of the asset or current delegate
     #[inline(always)]
     pub fn signer(&mut self, signer: solana_program::pubkey::Pubkey) -> &mut Self {
         self.signer = Some(signer);
@@ -142,7 +142,7 @@ impl RevokeBuilder {
 pub struct RevokeCpiAccounts<'a, 'b> {
     /// Asset account
     pub asset: &'b solana_program::account_info::AccountInfo<'a>,
-    /// Current owner of the asset or delegate
+    /// Owner of the asset or current delegate
     pub signer: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
@@ -152,7 +152,7 @@ pub struct RevokeCpi<'a, 'b> {
     pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Asset account
     pub asset: &'b solana_program::account_info::AccountInfo<'a>,
-    /// Current owner of the asset or delegate
+    /// Owner of the asset or current delegate
     pub signer: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: RevokeInstructionArgs,
@@ -272,7 +272,7 @@ impl<'a, 'b> RevokeCpiBuilder<'a, 'b> {
         self.instruction.asset = Some(asset);
         self
     }
-    /// Current owner of the asset or delegate
+    /// Owner of the asset or current delegate
     #[inline(always)]
     pub fn signer(
         &mut self,

--- a/clients/rust/asset/src/generated/instructions/update.rs
+++ b/clients/rust/asset/src/generated/instructions/update.rs
@@ -15,7 +15,7 @@ pub struct Update {
     pub asset: solana_program::pubkey::Pubkey,
     /// The authority of the asset
     pub authority: solana_program::pubkey::Pubkey,
-    /// Extension (asset) buffer account
+    /// Extension buffer (uninitialized asset) account
     pub buffer: Option<solana_program::pubkey::Pubkey>,
     /// The asset defining the group, if applicable
     pub group: Option<solana_program::pubkey::Pubkey>,
@@ -156,7 +156,7 @@ impl UpdateBuilder {
         self
     }
     /// `[optional account]`
-    /// Extension (asset) buffer account
+    /// Extension buffer (uninitialized asset) account
     #[inline(always)]
     pub fn buffer(&mut self, buffer: Option<solana_program::pubkey::Pubkey>) -> &mut Self {
         self.buffer = buffer;
@@ -248,7 +248,7 @@ pub struct UpdateCpiAccounts<'a, 'b> {
     pub asset: &'b solana_program::account_info::AccountInfo<'a>,
     /// The authority of the asset
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
-    /// Extension (asset) buffer account
+    /// Extension buffer (uninitialized asset) account
     pub buffer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The asset defining the group, if applicable
     pub group: Option<&'b solana_program::account_info::AccountInfo<'a>>,
@@ -266,7 +266,7 @@ pub struct UpdateCpi<'a, 'b> {
     pub asset: &'b solana_program::account_info::AccountInfo<'a>,
     /// The authority of the asset
     pub authority: &'b solana_program::account_info::AccountInfo<'a>,
-    /// Extension (asset) buffer account
+    /// Extension buffer (uninitialized asset) account
     pub buffer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The asset defining the group, if applicable
     pub group: Option<&'b solana_program::account_info::AccountInfo<'a>>,
@@ -470,7 +470,7 @@ impl<'a, 'b> UpdateCpiBuilder<'a, 'b> {
         self
     }
     /// `[optional account]`
-    /// Extension (asset) buffer account
+    /// Extension buffer (uninitialized asset) account
     #[inline(always)]
     pub fn buffer(
         &mut self,

--- a/clients/rust/asset/tests/extensions.rs
+++ b/clients/rust/asset/tests/extensions.rs
@@ -1,2 +1,3 @@
 #![cfg(feature = "test-sbf")]
 pub mod properties;
+pub mod royalties;

--- a/clients/rust/asset/tests/properties/mod.rs
+++ b/clients/rust/asset/tests/properties/mod.rs
@@ -29,8 +29,8 @@ async fn create() {
     // And an extension.
 
     let mut properties = PropertiesBuilder::default();
-    properties.add_text("name", "nifty");
-    properties.add_number("points", 0);
+    properties.add::<&str>("name", "nifty");
+    properties.add::<u64>("points", 0);
     let data = properties.data();
 
     // When we create a new asset.
@@ -102,9 +102,9 @@ async fn create_with_multiple() {
     metadata.set(Some("NIFTY"), None, None, None);
 
     let mut properties = PropertiesBuilder::default();
-    properties.add_text("name", "nifty");
-    properties.add_number("points", 0);
-    properties.add_boolean("active", true);
+    properties.add::<&str>("name", "nifty");
+    properties.add::<u64>("points", 0);
+    properties.add::<bool>("active", true);
 
     let mut attributes = AttributesBuilder::default();
     attributes.add("type", "solid");

--- a/clients/rust/asset/tests/royalties/mod.rs
+++ b/clients/rust/asset/tests/royalties/mod.rs
@@ -1,0 +1,90 @@
+#![cfg(feature = "test-sbf")]
+
+use nifty_asset::{
+    constraints::{Account, OperatorType, OwnedByBuilder},
+    extensions::{ExtensionBuilder, Royalties, RoyaltiesBuilder},
+    instructions::CreateBuilder,
+    state::{Asset, Discriminator, Standard, State},
+    types::{ExtensionInput, ExtensionType},
+    ZeroCopy,
+};
+use solana_program::system_program;
+use solana_program_test::{tokio, ProgramTest};
+use solana_sdk::{
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+
+#[tokio::test]
+async fn create() {
+    let mut context = ProgramTest::new("asset_program", nifty_asset::ID, None)
+        .start_with_context()
+        .await;
+
+    // Given a new keypair.
+
+    let asset = Keypair::new();
+
+    // And an extension.
+
+    let mut owned_by = OwnedByBuilder::default();
+    owned_by.set(Account::Recipient, &[system_program::ID]);
+
+    let mut royalties = RoyaltiesBuilder::default();
+    royalties.set(500, &mut owned_by);
+    let data = royalties.data();
+
+    // When we create a new asset.
+
+    let ix = CreateBuilder::new()
+        .asset(asset.pubkey())
+        .authority(context.payer.pubkey(), false)
+        .owner(context.payer.pubkey())
+        .payer(Some(context.payer.pubkey()))
+        .system_program(Some(system_program::id()))
+        .name("name".to_string())
+        .extensions(vec![ExtensionInput {
+            extension_type: ExtensionType::Royalties,
+            length: data.len() as u32,
+            data: Some(data),
+        }])
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &asset],
+        context.last_blockhash,
+    );
+    context.banks_client.process_transaction(tx).await.unwrap();
+
+    // Then an asset was created with the correct data.
+
+    let account = context
+        .banks_client
+        .get_account(asset.pubkey())
+        .await
+        .unwrap();
+    assert!(account.is_some());
+    let account = account.unwrap();
+
+    let account_data = account.data.as_ref();
+    let asset = Asset::load(account_data);
+
+    assert_eq!(asset.discriminator, Discriminator::Asset);
+    assert_eq!(asset.state, State::Unlocked);
+    assert_eq!(asset.standard, Standard::NonFungible);
+    assert_eq!(asset.authority, context.payer.pubkey());
+    assert_eq!(asset.owner, context.payer.pubkey());
+
+    // And we are expecting an extension on the account.
+
+    assert!(Asset::get_extensions(account_data).len() == 1);
+    let royalties = Asset::get::<Royalties>(account_data).unwrap();
+
+    assert_eq!(*royalties.basis_points, 500);
+    assert_eq!(
+        royalties.constraint.operator.operator_type(),
+        OperatorType::OwnedBy
+    );
+}

--- a/idls/asset_program.json
+++ b/idls/asset_program.json
@@ -10,7 +10,7 @@
           "isMut": true,
           "isSigner": true,
           "docs": [
-            "The unitialized buffer account"
+            "The uninitialized buffer account"
           ]
         },
         {
@@ -115,7 +115,7 @@
           "isSigner": true,
           "isOptional": true,
           "docs": [
-            "Optional authority for minting assets into a group"
+            "Group authority for creating an asset into a group"
           ]
         },
         {
@@ -276,7 +276,7 @@
           "isMut": false,
           "isSigner": true,
           "docs": [
-            "Current owner of the asset or delegate"
+            "Owner of the asset or current delegate"
           ]
         }
       ],
@@ -413,7 +413,7 @@
           "isSigner": false,
           "isOptional": true,
           "docs": [
-            "Extension (asset) buffer account"
+            "Extension buffer (uninitialized asset) account"
           ]
         },
         {

--- a/programs/asset/program/src/instruction.rs
+++ b/programs/asset/program/src/instruction.rs
@@ -12,7 +12,7 @@ pub enum Instruction {
     /// Closes an uninitialized asset (buffer) account.
     /// 
     /// You can only close the buffer account if it has not been used to create an asset.
-    #[account(0, signer, writable, name="buffer", desc = "The unitialized buffer account")]
+    #[account(0, signer, writable, name="buffer", desc = "The uninitialized buffer account")]
     #[account(1, writable, name="recipient", desc = "The account receiving refunded rent")]
     Close,
 
@@ -28,7 +28,7 @@ pub enum Instruction {
     #[account(1, optional_signer, name="authority", desc = "The authority of the asset")]
     #[account(2, name="owner", desc = "The owner of the asset")]
     #[account(3, optional, writable, name="group", desc = "Asset account of the group")]
-    #[account(4, optional, signer, name="group_authority", desc = "Optional authority for minting assets into a group")]
+    #[account(4, optional, signer, name="group_authority", desc = "Group authority for creating an asset into a group")]
     #[account(5, optional, signer, writable, name="payer", desc = "The account paying for the storage fees")]
     #[account(6, optional, name="system_program", desc = "The system program")]
     Create(MetadataInput),
@@ -52,7 +52,7 @@ pub enum Instruction {
 
     /// Revokes a delegate.
     #[account(0, writable, name="asset", desc = "Asset account")]
-    #[account(1, signer, name="signer", desc = "Current owner of the asset or delegate")]
+    #[account(1, signer, name="signer", desc = "Owner of the asset or current delegate")]
     Revoke(DelegateInput),
 
     /// Transfers ownership of the aseet to a new public key.
@@ -75,7 +75,7 @@ pub enum Instruction {
     /// Updates an asset.
     #[account(0, writable, name="asset", desc = "Asset account")]
     #[account(1, signer, name="authority", desc = "The authority of the asset")]
-    #[account(2, optional, writable, name="buffer", desc = "Extension (asset) buffer account")]
+    #[account(2, optional, writable, name="buffer", desc = "Extension buffer (uninitialized asset) account")]
     #[account(3, optional, name="group", desc = "The asset defining the group, if applicable")]
     #[account(4, optional, signer, writable, name="payer", desc = "The account paying for the storage fees")]
     #[account(5, optional, name="system_program", desc = "The system program")]

--- a/programs/proxy/src/processor/create.rs
+++ b/programs/proxy/src/processor/create.rs
@@ -92,7 +92,7 @@ pub fn process_create(
     };
 
     let data = PropertiesBuilder::with_capacity(30)
-        .add_number("last_transferred", Clock::get()?.unix_timestamp as u64)
+        .add::<u64>("last_transferred", Clock::get()?.unix_timestamp as u64)
         .data();
     let properties = ExtensionInput {
         extension_type: ExtensionType::Properties,

--- a/programs/proxy/src/processor/transfer.rs
+++ b/programs/proxy/src/processor/transfer.rs
@@ -96,7 +96,7 @@ pub fn process_transfer<'a>(
     // updates the properties (last tranferred)
 
     let data = PropertiesBuilder::with_capacity(30)
-        .add_number("last_transferred", Clock::get()?.unix_timestamp as u64)
+        .add::<u64>("last_transferred", Clock::get()?.unix_timestamp as u64)
         .data();
 
     UpdateCpiBuilder::new(nifty_asset_program)


### PR DESCRIPTION
This PR improves the `Properties` extension builder by using generics.

Before:
```rust
let mut builder = PropertiesBuilder::default();
builder.add_text("name", "asset");
builder.add_number("version", 1);
```

After:
```rust
let mut builder = PropertiesBuilder::default();
builder.add::<&str>("name", "asset");
builder.add::<u64>("version", 1);
```